### PR TITLE
Support Field Label Refreshing

### DIFF
--- a/magic-link/magic-link-user-app.php
+++ b/magic-link/magic-link-user-app.php
@@ -46,37 +46,42 @@ class Disciple_Tools_Magic_Links_Magic_User_App extends DT_Magic_Url_Base {
          *                          If True, lookup field to be provided within plugin for contacts only searching.
          *                          If false, Dropdown option to be provided for user, team or group selection.
          *      - fields:       List of fields to be displayed within magic link frontend form.
+         *      - field_refreshes:  Support field label updating.
          */
-        $field_settings = DT_Posts::get_post_field_settings( 'contacts' );
-        $this->meta     = [
-            'app_type'      => 'magic_link',
-            'post_type'     => $this->post_type,
-            'contacts_only' => false,
-            'fields'        => [
+        $this->meta = [
+            'app_type'       => 'magic_link',
+            'post_type'      => $this->post_type,
+            'contacts_only'  => false,
+            'fields'         => [
                 [
                     'id'    => 'name',
-                    'label' => $field_settings['name']['name']
+                    'label' => ''
                 ],
                 [
                     'id'    => 'milestones',
-                    'label' => $field_settings['milestones']['name']
+                    'label' => ''
                 ],
                 [
                     'id'    => 'overall_status',
-                    'label' => $field_settings['overall_status']['name']
+                    'label' => ''
                 ],
                 [
                     'id'    => 'faith_status',
-                    'label' => $field_settings['faith_status']['name']
+                    'label' => ''
                 ],
                 [
                     'id'    => 'contact_phone',
-                    'label' => $field_settings['contact_phone']['name']
+                    'label' => ''
                 ],
                 [
                     'id'    => 'comments',
                     'label' => __( 'Comments', 'disciple_tools' ) // Special Case!
                 ]
+            ],
+            'fields_refresh' => [
+                'enabled'    => true,
+                'post_type'  => 'contacts',
+                'ignore_ids' => [ 'comments' ]
             ]
         ];
 

--- a/magic-link/magic-links-api.php
+++ b/magic-link/magic-links-api.php
@@ -37,6 +37,29 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_API {
                 if ( ! empty( $root ) && is_array( $root ) ) {
                     foreach ( $root as $type ) {
                         if ( isset( $type['meta']['app_type'] ) && $type['meta']['app_type'] === 'magic_link' ) {
+
+                            // Determine if field label refreshing is required
+                            if ( isset( $type['meta']['fields_refresh'] ) && $type['meta']['fields_refresh']['enabled'] ) {
+
+                                // Fetch corresponding field settings
+                                $field_settings = DT_Posts::get_post_field_settings( $type['meta']['fields_refresh']['post_type'] );
+                                if ( ! empty( $field_settings ) ) {
+
+                                    // Refresh field label, assuming it is not to be ignored
+                                    $refreshed_fields = [];
+                                    foreach ( $type['meta']['fields'] ?? [] as $field ) {
+                                        if ( ! in_array( $field['id'], $type['meta']['fields_refresh']['ignore_ids'] ) ) {
+                                            $field['label'] = $field_settings[ $field['id'] ]['name'];
+                                        }
+                                        $refreshed_fields[] = $field;
+                                    }
+
+                                    // Update type fields
+                                    $type['meta']['fields'] = $refreshed_fields;
+                                }
+                            }
+
+                            // Assign type to returning array
                             $magic_link_types[] = $type;
                         }
                     }


### PR DESCRIPTION
Logic refactored so as to avoid having to call **_DT_Posts::get_post_field_settings()_** function within ml user app constructor and subsequently avoid any caching blocks.