### PR TITLE
Add option to display site logo

### DIFF
--- a/admin/js/links-tab.js
+++ b/admin/js/links-tab.js
@@ -385,6 +385,17 @@ jQuery(function ($) {
             config_table.find('tr.supports_create input[type=checkbox]').prop('checked', checked);
           }
 
+          if (type_obj['meta']['supports_logo'] ) {
+            config_table.find('tr.display_logo').show();
+            let checked = false;
+            let link_obj = fetch_link_obj($('#ml_main_col_available_link_objs_select').val());
+            if (link_obj && link_obj['type_config'] && link_obj['type_config']['display_logo']) {
+              checked = true;
+              has_config = true;
+            }
+            config_table.find('tr.display_logo input[type=checkbox]').prop('checked', checked);
+          }
+
           if (has_config) {
             config_table.show();
           }

--- a/admin/links-tab.php
+++ b/admin/links-tab.php
@@ -465,12 +465,17 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
     }
 
     private function main_column_ml_type_fields() {
+        $logo_url = $dt_nav_tabs['admin']['site']['icon'] ?? get_template_directory_uri() . '/dt-assets/images/disciple-tools-logo-white.png';
+        $custom_logo_url = get_option( 'custom_logo_url' );
+        if ( !empty( $custom_logo_url ) ) {
+            $logo_url = $custom_logo_url;
+        }
         ?>
         <table class="widefat striped" id="ml_main_col_ml_type_config_table" style="margin-bottom: 1rem;">
             <tbody>
                 <tr class="display_logo">
                     <input id="ml_main_col_ml_type_config_table_row_field_id" type="hidden" value="display_logo">
-                    <td><?php esc_html_e( "Display Site Logo", 'disciple_tools' ) ?></td>
+                    <td><?php esc_html_e( "Display Site Logo", 'disciple_tools' ) ?><img style="height:15px; margin-inline-start: 5px" src="<?php echo esc_html( $logo_url ) ?>"/></td>
                     <td><input id="ml_main_col_ml_type_config_table_row_field_enabled" type="checkbox"></td>
                 </tr>
                 <tr class="supports_create">

--- a/admin/links-tab.php
+++ b/admin/links-tab.php
@@ -468,11 +468,15 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
         ?>
         <table class="widefat striped" id="ml_main_col_ml_type_config_table" style="margin-bottom: 1rem;">
             <tbody>
+                <tr class="display_logo">
+                    <input id="ml_main_col_ml_type_config_table_row_field_id" type="hidden" value="display_logo">
+                    <td><?php esc_html_e( "Display Site Logo", 'disciple_tools' ) ?></td>
+                    <td><input id="ml_main_col_ml_type_config_table_row_field_enabled" type="checkbox"></td>
+                </tr>
                 <tr class="supports_create">
                     <input id="ml_main_col_ml_type_config_table_row_field_id" type="hidden" value="supports_create">
                     <td><?php esc_html_e( "Support creating new items", 'disciple_tools' ) ?></td>
                     <td><input id="ml_main_col_ml_type_config_table_row_field_enabled" type="checkbox"></td>
-
                 </tr>
             </tbody>
         </table>

--- a/magic-link/magic-link-user-posts-base.php
+++ b/magic-link/magic-link-user-posts-base.php
@@ -57,6 +57,7 @@ abstract class Disciple_Tools_Magic_Links_Magic_User_Posts_Base extends DT_Magic
             'post_type'      => $this->post_type,
             'contacts_only'  => false,
             'supports_create' => true,
+            'supports_logo'  => true,
             'fields'         => $fields,
             'fields_refresh' => [
                 'enabled'    => true,
@@ -228,6 +229,19 @@ abstract class Disciple_Tools_Magic_Links_Magic_User_Posts_Base extends DT_Magic
             body {
                 background-color: white;
                 padding: 1em;
+            }
+
+            header {
+                min-height: 30px;
+                position: relative;
+            }
+            header .logo {
+                max-height: 30px;
+                position: absolute;
+                left: 0;
+            }
+            header h2 {
+                text-align: center;
             }
 
             .api-content-div-style {
@@ -849,14 +863,22 @@ abstract class Disciple_Tools_Magic_Links_Magic_User_Posts_Base extends DT_Magic
         // Revert back to dt translations
         $this->hard_switch_to_default_dt_text_domain();
         $link_obj = Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_option_link_obj( $this->fetch_incoming_link_param( 'id' ) );
+
+        $display_logo = isset( $link_obj ) && property_exists( $link_obj, 'type_config' ) && property_exists( $link_obj->type_config, 'display_logo' ) && $link_obj->type_config->display_logo;
+        $logo_url = get_template_directory_uri() . '/dt-assets/images/disciple-tools-logo-white.png';
+        $custom_logo_url = get_option( 'custom_logo_url' );
+        if ( !empty( $custom_logo_url ) ) {
+            $logo_url = $custom_logo_url;
+        }
         ?>
         <div id="custom-style"></div>
         <div id="wrapper">
-            <div class="grid-x">
-                <div class="cell center">
-                    <h2 id="title"><b><?php esc_html_e( 'Updates Needed', 'disciple_tools' ) ?></b></h2>
-                </div>
-            </div>
+            <header>
+                <?php if ( $display_logo ): ?>
+                    <img src="<?php echo esc_attr( $logo_url ) ?>" class="logo" />
+                <?php endif; ?>
+                <h2 id="title"><b><?php esc_html_e( 'Updates Needed', 'disciple_tools' ) ?></b></h2>
+            </header>
             <hr>
             <div id="content">
                 <div id="assigned_posts_div" style="display: none;">


### PR DESCRIPTION
Displays site logo (including logic for custom logos) on magic link if option is enabled (disabled by default to keep current experience the same).