### PR TITLE
#73 - Set Email Subject When Sending Links

### DIFF
--- a/admin/js/links-tab.js
+++ b/admin/js/links-tab.js
@@ -112,8 +112,9 @@ jQuery(function ($) {
     });
 
     reset_section(display, $('#ml_main_col_message'), function () {
+      let default_msg_subject = window.dt_magic_links.dt_default_message_subject;
       let default_msg = window.dt_magic_links.dt_default_message;
-      reset_section_message(default_msg);
+      reset_section_message(default_msg_subject, default_msg);
     });
 
     reset_section(display, $('#ml_main_col_schedules'), function () {
@@ -205,7 +206,8 @@ jQuery(function ($) {
     }
   }
 
-  function reset_section_message(message) {
+  function reset_section_message(subject, message) {
+    $('#ml_main_col_msg_textarea_subject').val(subject);
     $('#ml_main_col_msg_textarea').val(message);
   }
 
@@ -1140,6 +1142,7 @@ jQuery(function ($) {
 
     let assigned_users_teams = fetch_assigned_users_teams();
 
+    let message_subject = $('#ml_main_col_msg_textarea_subject').val().trim();
     let message = $('#ml_main_col_msg_textarea').val().trim();
 
     let scheduling_enabled = $('#ml_main_col_schedules_enabled').prop('checked');
@@ -1209,6 +1212,7 @@ jQuery(function ($) {
           'links_expire_auto_refresh_enabled': links_expire_auto_refresh_enabled
         },
 
+        'message_subject': message_subject,
         'message': message,
 
         'schedule': {
@@ -1333,7 +1337,7 @@ jQuery(function ($) {
       });
 
       reset_section(true, $('#ml_main_col_message'), function () {
-        reset_section_message(link_obj['message']);
+        reset_section_message(link_obj['message_subject'], link_obj['message']);
       });
 
       reset_section(true, $('#ml_main_col_schedules'), function () {
@@ -1375,6 +1379,7 @@ jQuery(function ($) {
       links_never_expires: $('#ml_main_col_link_manage_links_expire_never').prop('checked'),
       links_refreshed_before_send: $('#ml_main_col_schedules_links_refreshed_before_send').prop('checked'),
       links_expire_auto_refresh_enabled: $('#ml_main_col_link_manage_links_expire_auto_refresh_enabled').prop('checked'),
+      message_subject: $('#ml_main_col_msg_textarea_subject').val(),
       message: $('#ml_main_col_msg_textarea').val()
     };
 

--- a/admin/links-tab-docs.php
+++ b/admin/links-tab-docs.php
@@ -74,6 +74,7 @@
     Message
 </div>
 <div id="ml_links_right_docs_message_content" style="display: none;">
+    Specify subject to be used when sending messages. For example, if you are using the Email Sending Channel, then specified message subject will overwrite global email subject.<br><br>
     Specify text to be used when sending messages. <br><br>
     The message content can support free-form plain text, with the use of placeholders; which will be replaced during
     message dispatch. <br><br>The following placeholders are currently supported:<br>

--- a/admin/links-tab.php
+++ b/admin/links-tab.php
@@ -52,6 +52,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 'dt_endpoint_user_links_manage' => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_user_links_manage_url(),
                 'dt_endpoint_assigned_manage'   => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_assigned_manage_url(),
                 'dt_endpoint_get_post_record'   => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_get_post_record_url(),
+                'dt_default_message_subject'    => '',
                 'dt_default_message'            => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_default_send_msg(),
                 'dt_default_send_channel_id'    => Disciple_Tools_Bulk_Magic_Link_Sender_API::$channel_email_id,
                 'dt_base_url'                   => rest_url(),
@@ -634,6 +635,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
 
     private function main_column_message() {
         ?>
+        <input style="min-width: 100%;" type="text" id="ml_main_col_msg_textarea_subject" value="" placeholder="Message Subject"/><br>
         <textarea style="min-width: 100%;" id="ml_main_col_msg_textarea" rows="10"></textarea>
         <?php
     }

--- a/magic-link/magic-links-api.php
+++ b/magic-link/magic-links-api.php
@@ -601,6 +601,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_API {
                     // Dispatch message using specified sending channel
                     $send_result = call_user_func( $sending_channel['send'], [
                         'user'    => $user,
+                        'message_subject' => $link_obj->message_subject,
                         'message' => $message
                     ] );
 

--- a/magic-link/magic-links-default-filters.php
+++ b/magic-link/magic-links-default-filters.php
@@ -87,7 +87,7 @@ function dt_email_sending_channel_send( $params ) {
 
                     // Build and dispatch notification email!
                     $email_to        = $email;
-                    $email_subject   = $email_obj['subject'] ?? Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_default_email_subject();
+                    $email_subject = !empty( $params['message_subject'] ) ? $params['message_subject'] : ( $email_obj['subject'] ?? Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_default_email_subject() );
                     $email_body      = $params['message'];
                     $email_headers[] = 'Content-Type: text/plain; charset=UTF-8';
                     if ( ! empty( $email_obj['from_name'] ) && ! empty( $email_obj['from_email'] ) ) {

--- a/rest-api/rest-api.php
+++ b/rest-api/rest-api.php
@@ -329,6 +329,10 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Endpoints {
                  * If present, capture latest message text.
                  */
 
+                if ( ! empty( $params['message_subject'] ) ) {
+                    $link_obj->message_subject = $params['message_subject'];
+                }
+
                 if ( ! empty( $params['message'] ) ) {
                     $link_obj->message = $params['message'];
                 }


### PR DESCRIPTION
- fixes: #73 
- Links Tab Message section updated to include message subject.
  - When specified, email messages will use entered text as email subject. Otherwise, global (set within Email Tab) subject to be used.

![Screenshot 2023-01-20 at 16 18 12](https://user-images.githubusercontent.com/19330800/213753525-4319cc5a-773f-42c0-9689-45d7186fd5db.png)

![Screenshot 2023-01-20 at 16 21 07](https://user-images.githubusercontent.com/19330800/213753571-04029e71-3a75-4164-b24e-1495e1c98d99.png)

![Screenshot 2023-01-20 at 16 18 52](https://user-images.githubusercontent.com/19330800/213753660-391c8e45-3822-4dfd-9a14-25177f920436.png)

