### PR TITLE
#85 - Group Members Syncing

### DIFF
--- a/admin/links-tab.php
+++ b/admin/links-tab.php
@@ -52,6 +52,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 'dt_endpoint_user_links_manage' => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_user_links_manage_url(),
                 'dt_endpoint_assigned_manage'   => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_assigned_manage_url(),
                 'dt_endpoint_get_post_record'   => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_get_post_record_url(),
+                'dt_endpoint_references'        => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_references(),
                 'dt_default_message_subject'    => '',
                 'dt_default_message'            => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_default_send_msg(),
                 'dt_default_send_channel_id'    => Disciple_Tools_Bulk_Magic_Link_Sender_API::$channel_email_id,
@@ -204,6 +205,16 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 </td>
             </tr>
             </tbody>
+            <tfoot>
+            <tr>
+                <td>
+                    <span style="float:right;">
+                        <button type="submit" id="ml_main_col_link_objs_manage_update_but"
+                                class="button float-right ml-links-update-but"><?php esc_html_e( "Update", 'disciple_tools' ) ?></button>
+                    </span>
+                </td>
+            </tr>
+            </tfoot>
         </table>
         <br>
         <!-- End Box -->
@@ -222,6 +233,16 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 </td>
             </tr>
             </tbody>
+            <tfoot>
+            <tr>
+                <td>
+                    <span style="float:right;">
+                        <button type="submit" id="ml_main_col_ml_type_fields_update_but"
+                                class="button float-right ml-links-update-but"><?php esc_html_e( "Update", 'disciple_tools' ) ?></button>
+                    </span>
+                </td>
+            </tr>
+            </tfoot>
         </table>
         <br>
         <!-- End Box -->
@@ -244,6 +265,16 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 </td>
             </tr>
             </tbody>
+            <tfoot>
+            <tr>
+                <td colspan="2">
+                    <span style="float:right;">
+                        <button type="submit" id="ml_main_col_assign_users_teams_update_but"
+                                class="button float-right ml-links-update-but"><?php esc_html_e( "Update", 'disciple_tools' ) ?></button>
+                    </span>
+                </td>
+            </tr>
+            </tfoot>
         </table>
         <br>
         <!-- End Box -->
@@ -277,7 +308,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 <td>
                     <span style="float:right;">
                         <button type="submit" id="ml_main_col_link_manage_update_but"
-                                class="button float-right"><?php esc_html_e( "Update", 'disciple_tools' ) ?></button>
+                                class="button float-right ml-links-update-but"><?php esc_html_e( "Update", 'disciple_tools' ) ?></button>
                     </span>
                 </td>
             </tr>
@@ -303,6 +334,16 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 </td>
             </tr>
             </tbody>
+            <tfoot>
+            <tr>
+                <td>
+                    <span style="float:right;">
+                        <button type="submit" id="ml_main_col_message_update_but"
+                                class="button float-right ml-links-update-but"><?php esc_html_e( "Update", 'disciple_tools' ) ?></button>
+                    </span>
+                </td>
+            </tr>
+            </tfoot>
         </table>
         <br>
         <!-- End Box -->
@@ -321,6 +362,16 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 </td>
             </tr>
             </tbody>
+            <tfoot>
+            <tr>
+                <td>
+                    <span style="float:right;">
+                        <button type="submit" id="ml_main_col_update_but"
+                                class="button float-right ml-links-update-but"><?php esc_html_e( "Update", 'disciple_tools' ) ?></button>
+                    </span>
+                </td>
+            </tr>
+            </tfoot>
         </table>
         <br>
         <!-- End Box -->
@@ -335,11 +386,6 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
         </form>
 
         <span style="float:left; display: none; font-weight: bold;" id="ml_main_col_update_msg"></span>
-
-        <span style="float:right;">
-            <button style="display: none;" type="submit" id="ml_main_col_update_but"
-                    class="button float-right"><?php esc_html_e( "Update", 'disciple_tools' ) ?></button>
-        </span>
         <?php
     }
 

--- a/magic-link/magic-links-api.php
+++ b/magic-link/magic-links-api.php
@@ -921,6 +921,10 @@ Thanks!';
         return trailingslashit( site_url() ) . 'wp-json/disciple_tools_magic_links/v1/get_post_record';
     }
 
+    public static function fetch_endpoint_references(): string {
+        return trailingslashit( site_url() ) . 'wp-json/disciple_tools_magic_links/v1/references';
+    }
+
     public static function fetch_endpoint_report_url(): string {
         return trailingslashit( site_url() ) . 'wp-json/disciple_tools_magic_links/v1/report';
     }

--- a/rest-api/rest-api.php
+++ b/rest-api/rest-api.php
@@ -438,8 +438,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Endpoints {
                     $response['dt_groups'] = Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_dt_groups();
                     break;
             }
-
-        } else{
+        } else {
             $response['success'] = false;
             $response['message'] = 'Unable to execute action, due to missing parameters.';
         }

--- a/rest-api/rest-api.php
+++ b/rest-api/rest-api.php
@@ -67,6 +67,15 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Endpoints {
                 }
             ]
         );
+        register_rest_route(
+            $namespace, '/references', [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'references' ],
+                'permission_callback' => function ( WP_REST_Request $request ) {
+                    return $this->has_permission();
+                }
+            ]
+        );
     }
 
     public function get_post_record( WP_REST_Request $request ): array {
@@ -406,6 +415,33 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Endpoints {
             $response['success'] = $success;
             $response['message'] = $success ? 'Loaded data for report id: ' . $id : 'Unable to load data for report id: ' . $id;
             $response['report']  = $success ? $report : null;
+        }
+
+        return $response;
+    }
+
+    public function references( WP_REST_Request $request ): array{
+
+        // Prepare response payload
+        $response = [];
+
+        $params = $request->get_params();
+        if ( isset( $params['action'] ) ){
+
+            // Execute accordingly, based on specified action
+            switch ($params['action']){
+                case 'refresh':
+                    $response['success'] = true;
+                    $response['message'] = 'References action[' . $params['action'] . '] successfully executed.';
+                    $response['dt_users'] = Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_dt_users();
+                    $response['dt_teams'] = Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_dt_teams();
+                    $response['dt_groups'] = Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_dt_groups();
+                    break;
+            }
+
+        } else{
+            $response['success'] = false;
+            $response['message'] = 'Unable to execute action, due to missing parameters.';
         }
 
         return $response;


### PR DESCRIPTION
- fixes: #85 
---

- Assigned group & team member syncing functionality now implemented and functions as follows:
    - A new `Refresh` option is now available on `Group` and `Team` parent rows.
    - Once refresh confirmation has been given, a group/team's state is refreshed to show it's latest state, ensuring to remove/add members accordingly.
    - See screenshots below.


![Screenshot 2023-02-16 at 12 10 11](https://user-images.githubusercontent.com/19330800/219364605-f3426d52-1c0a-4c54-b4af-8f713b064bb8.png)


![Screenshot 2023-02-16 at 12 10 30](https://user-images.githubusercontent.com/19330800/219364714-19b699fc-672b-49a8-80c9-d6d55301f60d.png)


![Screenshot 2023-02-16 at 12 11 18](https://user-images.githubusercontent.com/19330800/219364763-c41a8664-eca0-4df9-89c4-12b4c06e791f.png)