### PR TITLE
ML#102 - Template As Custom Textfield As Textarea

### DIFF
--- a/admin/js/templates-tab.js
+++ b/admin/js/templates-tab.js
@@ -192,7 +192,7 @@ jQuery(function ($) {
 
       // Reload previously selected fields
       $.each(data['fields'], function (idx, field) {
-        $('.connected-sortable-fields').append(build_new_selected_field_html(field['id'], field['label'], field['type'], field['enabled'], (field['translations'] !== undefined) ? field['translations'] : {}));
+        $('.connected-sortable-fields').append(build_new_selected_field_html(field['id'], field['label'], field['type'], field['enabled'], (field['translations'] !== undefined) ? field['translations'] : {}, (field['custom_form_field_type'] !== undefined) ? field['custom_form_field_type'] : 'textfield'));
       });
 
       // Instantiate sortable fields capabilities
@@ -566,13 +566,23 @@ jQuery(function ($) {
     return already_selected;
   }
 
-  function build_new_selected_field_html(field_id, field_label, field_type, field_enabled, field_translations) {
+  function build_new_selected_field_html(field_id, field_label, field_type, field_enabled, field_translations, field_custom_form_type = 'textfield') {
 
-    // Ensure default field labels are disabled and cannot be overwritten
+    // Ensure default field labels are disabled and cannot be overwritten, along with any other field type specific settings.
     let label_disabled_html = '';
+    let final_form_custom_field_type_html = '';
     switch (field_type) {
       case 'dt' : {
         label_disabled_html = 'disabled';
+        break;
+      }
+      case 'custom' : {
+        final_form_custom_field_type_html = `
+            <select id="ml_main_col_selected_fields_sortable_form_custom_field_type">
+                <option value="textfield" ${(field_custom_form_type === 'textfield') ? 'selected':''}>Textfield</option>
+                <option value="textarea" ${(field_custom_form_type === 'textarea') ? 'selected':''}>Textarea</option>
+            </select>
+        `;
         break;
       }
     }
@@ -595,6 +605,7 @@ jQuery(function ($) {
                                type="text" value="${field_label}" ${label_disabled_html}/>
                     </td>
                     <td style="text-align: right;">
+                        ${final_form_custom_field_type_html}
                         ${build_translation_button_html(field_id, field_label, field_type, field_translations, label_disabled_html)}
                         <button type="submit" class="button float-right connected-sortable-fields-remove-but">
                             Remove
@@ -636,7 +647,7 @@ jQuery(function ($) {
     let message = $('#ml_main_col_msg_textarea').val();
     let fields = fetch_selected_fields();
 
-    // Validate values so as to ensure all is present and correct within that department! ;)
+    // Validate values, to ensure all is present and correct within that department! ;)
     let update_msg = null;
     let update_msg_ele = $('#ml_main_col_update_msg');
     update_msg_ele.fadeOut('fast');
@@ -693,13 +704,15 @@ jQuery(function ($) {
       let enabled = $(field_div).find('#ml_main_col_selected_fields_sortable_field_enabled').prop('checked');
       let label = $(field_div).find('#ml_main_col_selected_fields_sortable_field_label').val();
       let translations = (type === 'dt') ? {} : JSON.parse(decodeURIComponent($(field_div).find('.connected-sortable-fields-translate-but').data('field_translations')));
+      let custom_form_field_type = (type === 'custom') ? $(field_div).find('#ml_main_col_selected_fields_sortable_form_custom_field_type').val() : '';
 
       fields.push({
         'id': id,
         'type': type,
         'enabled': enabled,
         'label': label,
-        'translations': translations
+        'translations': translations,
+        'custom_form_field_type': custom_form_field_type
       });
     });
 

--- a/magic-link/magic-link-templates.php
+++ b/magic-link/magic-link-templates.php
@@ -225,9 +225,18 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
             // Support custom field label translations; or simply default to initial label entry.
             $label = ( ! empty( $field['translations'] ) && isset( $field['translations'][ determine_locale() ] ) ) ? $field['translations'][ determine_locale() ]['translation'] : $field['label'];
 
-            echo esc_html( $label ); ?></div>
-        <input id="<?php echo esc_html( $field['id'] ); ?>" type="text" class="text-input" value="">
+            echo esc_html( $label ); ?>
+        </div>
         <?php
+        if ( isset( $field['custom_form_field_type'] ) && $field['custom_form_field_type'] == 'textarea' ){
+            ?>
+            <textarea id="<?php echo esc_html( $field['id'] ); ?>"></textarea>
+            <?php
+        } else {
+            ?>
+            <input id="<?php echo esc_html( $field['id'] ); ?>" type="text" class="text-input" value="">
+            <?php
+        }
     }
 
     private function adjust_template_title_translation( $title, $title_translations ) {


### PR DESCRIPTION
- fixes: #102 
---

- Users now have the ability to selected the field type to be adopted when displaying custom template form fields.

![Screenshot 2023-05-01 at 13 17 02](https://user-images.githubusercontent.com/19330800/235450595-7bb8c0dd-14f9-49ec-bf71-73112892fa06.png)

![Screenshot 2023-05-01 at 13 17 15](https://user-images.githubusercontent.com/19330800/235450629-d53f0b63-4aa7-4f1e-98b1-e514472185b2.png)
