### PR TITLE
ML#104 - Scheduling Clarity

### DIFF
--- a/admin/general-tab.php
+++ b/admin/general-tab.php
@@ -256,9 +256,14 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_General {
                         $last_scheduled_run = ! empty( $link_obj->schedule->last_schedule_run ) ? Disciple_Tools_Bulk_Magic_Link_Sender_API::format_timestamp_in_local_time_zone( $link_obj->schedule->last_schedule_run ) : '---';
                         $last_success_send  = ! empty( $link_obj->schedule->last_success_send ) ? Disciple_Tools_Bulk_Magic_Link_Sender_API::format_timestamp_in_local_time_zone( $link_obj->schedule->last_success_send ) : '---';
                         $next_scheduled_run = '---';
-                        if ( ! empty( $link_obj->schedule->freq_amount ) && ! empty( $link_obj->schedule->freq_time_unit ) && ! empty( $link_obj->schedule->last_schedule_run ) ) {
-                            $next_run           = strtotime( '+' . $link_obj->schedule->freq_amount . ' ' . $link_obj->schedule->freq_time_unit, $link_obj->schedule->last_schedule_run );
-                            $next_scheduled_run = Disciple_Tools_Bulk_Magic_Link_Sender_API::format_timestamp_in_local_time_zone( $next_run );
+
+                        if ( ( isset( $link_obj->schedule->enabled ) && $link_obj->schedule->enabled ) && ! empty( $link_obj->schedule->freq_amount ) && ! empty( $link_obj->schedule->freq_time_unit ) && ! empty( $link_obj->schedule->last_schedule_run ) ){
+                            $next_run = strtotime( '+' . $link_obj->schedule->freq_amount . ' ' . $link_obj->schedule->freq_time_unit, $link_obj->schedule->last_schedule_run );
+
+                            // Ensure next run is in the future.
+                            if ( $next_run > time() ){
+                                $next_scheduled_run = Disciple_Tools_Bulk_Magic_Link_Sender_API::format_timestamp_in_local_time_zone( $next_run );
+                            }
                         }
 
                         ?>

--- a/admin/js/links-tab.js
+++ b/admin/js/links-tab.js
@@ -1388,6 +1388,7 @@ jQuery(function ($) {
       reset_section(true, $('#ml_main_col_schedules'), function () {
         if (link_obj['schedule']) {
           reset_section_schedules(link_obj['schedule']['enabled'], link_obj['schedule']['freq_amount'], link_obj['schedule']['freq_time_unit'], link_obj['schedule']['sending_channel'], link_obj['schedule']['last_schedule_run'], link_obj['schedule']['last_success_send'], link_obj['schedule']['links_refreshed_before_send'], true);
+          handle_next_scheduled_run_request();
         }
       });
 
@@ -1454,6 +1455,31 @@ jQuery(function ($) {
 
       }
     });
+  }
+
+  function handle_next_scheduled_run_request() {
+
+    // Create request payload
+    let payload = {
+      link_obj_id: $('#ml_main_col_link_objs_manage_id').val()
+    };
+
+    // Dispatch next scheduled run request.
+    $.ajax({
+      url: window.dt_magic_links.dt_endpoint_next_scheduled_run,
+      method: 'POST',
+      data: payload,
+      beforeSend: (xhr) => {
+        xhr.setRequestHeader("X-WP-Nonce", window.dt_admin_scripts.nonce);
+      },
+      success: function (data) {
+        $('#ml_main_col_schedules_last_schedule_run_td').html((data['success'] && (data['next_run_ts'] > 0)) ? data['next_run_label'] + ' - [ ' + data['next_run_relative'] + ' ]' : '---');
+      },
+      error: function (data) {
+        console.log(data);
+      }
+    });
+
   }
 
   function handle_docs_request(title_div, content_div) {

--- a/admin/links-tab.php
+++ b/admin/links-tab.php
@@ -49,6 +49,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 'dt_groups'                     => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_dt_groups(),
                 'dt_magic_link_objects'         => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_option_link_objs(),
                 'dt_endpoint_send_now'          => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_send_now_url(),
+                'dt_endpoint_next_scheduled_run'          => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_next_scheduled_run_url(),
                 'dt_endpoint_user_links_manage' => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_user_links_manage_url(),
                 'dt_endpoint_assigned_manage'   => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_assigned_manage_url(),
                 'dt_endpoint_get_post_record'   => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_get_post_record_url(),
@@ -276,7 +277,11 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
             </tbody>
             <tfoot>
             <tr>
-                <td colspan="2">
+                <td>
+                    <button disabled style="min-width: 100%;" type="submit" id="ml_main_col_schedules_send_now_but"
+                            class="button float-right"><?php esc_html_e( 'Send Now To All Assigned Users', 'disciple_tools' ) ?></button>
+                </td>
+                <td>
                     <span style="float:right;">
                         <button type="submit" id="ml_main_col_assign_users_teams_update_but"
                                 class="button float-right ml-links-update-but"><?php esc_html_e( 'Update', 'disciple_tools' ) ?></button>
@@ -765,13 +770,12 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 </td>
             </tr>
             <tr>
-                <td style="vertical-align: middle;" colspan="2">
+                <td style="vertical-align: middle;">
                     <input type="hidden" id="ml_main_col_schedules_last_schedule_run" value=""/>
                     <input type="hidden" id="ml_main_col_schedules_last_success_send" value=""/>
-
-                    <button disabled style="min-width: 100%;" type="submit" id="ml_main_col_schedules_send_now_but"
-                            class="button float-right"><?php esc_html_e( 'Send Now', 'disciple_tools' ) ?></button>
+                    Next Scheduled Run
                 </td>
+                <td id="ml_main_col_schedules_last_schedule_run_td">---</td>
             </tr>
         </table>
         <?php

--- a/magic-link/magic-links-api.php
+++ b/magic-link/magic-links-api.php
@@ -909,6 +909,10 @@ Thanks!';
         return trailingslashit( site_url() ) . 'wp-json/disciple_tools_magic_links/v1/send_now';
     }
 
+    public static function fetch_endpoint_next_scheduled_run_url(): string {
+        return trailingslashit( site_url() ) . 'wp-json/disciple_tools_magic_links/v1/next_scheduled_run';
+    }
+
     public static function fetch_endpoint_user_links_manage_url(): string {
         return trailingslashit( site_url() ) . 'wp-json/disciple_tools_magic_links/v1/user_links_manage';
     }


### PR DESCRIPTION
- fixes: #104 
---

- Relocated Send Now button.
- Displaying next scheduled run and relative time within Schedule Management section of Links Tab.

![Screenshot 2023-05-11 at 13 35 52](https://github.com/DiscipleTools/disciple-tools-bulk-magic-link-sender/assets/19330800/397c526f-96b3-42d1-9682-f80d598c816b)

![Screenshot 2023-05-11 at 13 36 12](https://github.com/DiscipleTools/disciple-tools-bulk-magic-link-sender/assets/19330800/b68d068b-d392-4d16-b1f2-13a3a1796d34)
