### PR TITLE
#101 & #107 - Ability To Schedule By Weekday & Time + Support Different Template Types

### DIFF
--- a/admin/general-tab.php
+++ b/admin/general-tab.php
@@ -253,7 +253,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_General {
                     if ( $link_obj->enabled ) {
 
                         $last_cron_run      = Disciple_Tools_Bulk_Magic_Link_Sender_API::format_timestamp_in_local_time_zone( Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_option( Disciple_Tools_Bulk_Magic_Link_Sender_API::$option_dt_magic_links_last_cron_run ) );
-                        $last_scheduled_run = ! empty( $link_obj->schedule->last_schedule_run ) ? Disciple_Tools_Bulk_Magic_Link_Sender_API::format_timestamp_in_local_time_zone( $link_obj->schedule->last_schedule_run ) : '---';
+                        $last_scheduled_run = !empty( $link_obj->schedule->last_schedule_run ) ? ( ( $link_obj->schedule->last_schedule_run > time() ) ? 'Manual Scheduling Detected' : Disciple_Tools_Bulk_Magic_Link_Sender_API::format_timestamp_in_local_time_zone( $link_obj->schedule->last_schedule_run ) ) : '---';
                         $last_success_send  = ! empty( $link_obj->schedule->last_success_send ) ? Disciple_Tools_Bulk_Magic_Link_Sender_API::format_timestamp_in_local_time_zone( $link_obj->schedule->last_success_send ) : '---';
                         $next_scheduled_run = '---';
 

--- a/admin/js/links-tab.js
+++ b/admin/js/links-tab.js
@@ -249,7 +249,7 @@ jQuery(function ($) {
       timePicker: true,
       minDate: moment(),
       locale: {
-        format: 'dddd, MMMM Do YYYY, h:mm A'
+        format: 'dddd, MMMM Do YYYY, h:mm A Z'
       }
     }, function (start, end, label) {
 

--- a/admin/js/templates-tab.js
+++ b/admin/js/templates-tab.js
@@ -213,10 +213,10 @@ jQuery(function ($) {
     name: '',
     title: '',
     title_translations: {},
+    type: 'single-record',
     custom_fields: '',
     show_recent_comments: true,
-    send_submission_notifications: true,
-    list_sub_assigned_contacts: false
+    send_submission_notifications: true
   }, callback = function () {
   }) {
     let view_template_details = $('#ml_main_col_template_details');
@@ -228,11 +228,11 @@ jQuery(function ($) {
         $('#ml_main_col_template_details_name').val(data.name);
         $('#ml_main_col_template_details_title').val(data.title);
         $('#ml_main_col_template_details_title_translate_but').data('field_translations', encodeURIComponent(JSON.stringify(data.title_translations)));
+        $('#ml_main_col_template_details_type').val(data.type);
         $('.template-title-translate-but-label').text(Object.keys(data.title_translations).length);
         $('#ml_main_col_template_details_custom_fields').val(data.custom_fields);
         $('#ml_main_col_template_details_show_recent_comments').prop('checked', data.show_recent_comments);
         $('#ml_main_col_template_details_send_submission_notifications').prop('checked', data.send_submission_notifications);
-        $('#ml_main_col_template_details_list_sub_assigned_contacts').prop('checked', data.list_sub_assigned_contacts);
         callback();
       });
 
@@ -242,11 +242,11 @@ jQuery(function ($) {
       $('#ml_main_col_template_details_name').val(data.name);
       $('#ml_main_col_template_details_title').val(data.title);
       $('#ml_main_col_template_details_title_translate_but').data('field_translations', encodeURIComponent(JSON.stringify(data.title_translations)));
+      $('#ml_main_col_template_details_type').val(data.type);
       $('.template-title-translate-but-label').text(Object.keys(data.title_translations).length);
       $('#ml_main_col_template_details_custom_fields').val(data.custom_fields);
       $('#ml_main_col_template_details_show_recent_comments').prop('checked', data.show_recent_comments);
       $('#ml_main_col_template_details_send_submission_notifications').prop('checked', data.send_submission_notifications);
-      $('#ml_main_col_template_details_list_sub_assigned_contacts').prop('checked', data.list_sub_assigned_contacts);
       view_template_details.fadeIn(fade_speed, function () {
         callback();
       });
@@ -365,10 +365,10 @@ jQuery(function ($) {
                 name: template['name'],
                 title: template['title'],
                 title_translations: template['title_translations'] ?? {},
+                type: template['type'] ?? 'single-record',
                 custom_fields: '',
                 show_recent_comments: template['show_recent_comments'],
-                send_submission_notifications: template['send_submission_notifications'] ?? true,
-                list_sub_assigned_contacts: template['list_sub_assigned_contacts'] ?? false
+                send_submission_notifications: template['send_submission_notifications'] ?? true
               });
               template_views_selected_fields(false, 'slow', {fields: template['fields']});
               template_views_message(false, 'slow', {text: template['message']});
@@ -641,9 +641,9 @@ jQuery(function ($) {
     let name = $('#ml_main_col_template_details_name').val();
     let title = $('#ml_main_col_template_details_title').val();
     let title_translations = JSON.parse(decodeURIComponent($('#ml_main_col_template_details_title_translate_but').data('field_translations')));
+    let type = $('#ml_main_col_template_details_type').val();
     let show_recent_comments = $('#ml_main_col_template_details_show_recent_comments').prop('checked');
     let send_submission_notifications = $('#ml_main_col_template_details_send_submission_notifications').prop('checked');
-    let list_sub_assigned_contacts = $('#ml_main_col_template_details_list_sub_assigned_contacts').prop('checked');
     let message = $('#ml_main_col_msg_textarea').val();
     let fields = fetch_selected_fields();
 
@@ -680,9 +680,9 @@ jQuery(function ($) {
         'name': name,
         'title': title,
         'title_translations': title_translations,
+        'type': type,
         'show_recent_comments': show_recent_comments,
         'send_submission_notifications': send_submission_notifications,
-        'list_sub_assigned_contacts': list_sub_assigned_contacts,
         'message': message,
         'fields': fields
       };

--- a/admin/links-tab.php
+++ b/admin/links-tab.php
@@ -739,6 +739,17 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 </td>
             </tr>
             <tr>
+                <td style="vertical-align: middle;">
+                    <input type="hidden" id="ml_main_col_schedules_last_schedule_run" value=""/>
+                    <input type="hidden" id="ml_main_col_schedules_last_success_send" value=""/>
+                    Next Scheduled Run
+                </td>
+                <td>
+                    <input type="text" id="ml_main_col_schedules_next_schedule_run_date_picker" style="min-width: 100%;" />
+                    <span id="ml_main_col_schedules_next_schedule_run_relative_time" style="color: grey; font-size: 12px;"></span>
+                </td>
+            </tr>
+            <tr>
                 <td style="vertical-align: middle;">Sending Channel [<a href="#" class="ml-links-docs"
                                                                         data-title="ml_links_right_docs_send_channel_title"
                                                                         data-content="ml_links_right_docs_send_channel_content">&#63;</a>]
@@ -768,14 +779,6 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Links {
                 <td>
                     <input type="checkbox" id="ml_main_col_schedules_links_refreshed_before_send" value=""/>
                 </td>
-            </tr>
-            <tr>
-                <td style="vertical-align: middle;">
-                    <input type="hidden" id="ml_main_col_schedules_last_schedule_run" value=""/>
-                    <input type="hidden" id="ml_main_col_schedules_last_success_send" value=""/>
-                    Next Scheduled Run
-                </td>
-                <td id="ml_main_col_schedules_last_schedule_run_td">---</td>
             </tr>
         </table>
         <?php

--- a/admin/templates-tab-docs.php
+++ b/admin/templates-tab-docs.php
@@ -1,3 +1,16 @@
+<!-- Template Type -->
+<div id="ml_templates_right_docs_template_type_title" style="display: none;">
+    Template Type
+</div>
+<div id="ml_templates_right_docs_template_type_content" style="display: none;">
+    Specify how this template will function when form is displayed to end users.<br><br>
+    <hr>
+
+    <b>Single Record</b><br>Only assigned user's record will be updated.<br><br>
+    <b>List Sub-Assigned Contacts</b><br>If link form recipient is also sub-assigned on other records, then a list of sub-assignments will be displayed.<br><br>
+</div>
+<!-- Template Type -->
+
 <!-- Custom Fields -->
 <div id="ml_templates_right_docs_custom_fields_title" style="display: none;">
     Custom Fields
@@ -17,15 +30,6 @@
     When the user submits the magic link, a comment will be added to corresponding record @mentioning the assigned-to user (if there is one).
 </div>
 <!-- Send Submission Notifications -->
-
-<!-- List Sub-Assigned Contacts -->
-<div id="ml_templates_right_docs_list_sub_assigned_contacts_title" style="display: none;">
-    List Sub-Assigned Contacts
-</div>
-<div id="ml_templates_right_docs_list_sub_assigned_contacts_content" style="display: none;">
-    If link form recipient is also sub-assigned on other records, then a list of sub-assignments will be displayed.
-</div>
-<!-- List Sub-Assigned Contacts -->
 
 <!-- Message -->
 <div id="ml_templates_right_docs_message_title" style="display: none;">

--- a/admin/templates-tab.php
+++ b/admin/templates-tab.php
@@ -426,6 +426,18 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
                 </td>
             </tr>
             <tr>
+                <td style="vertical-align: middle;">Template Type [<a href="#" class="ml-templates-docs"
+                                                                                   data-title="ml_templates_right_docs_template_type_title"
+                                                                                   data-content="ml_templates_right_docs_template_type_content">&#63;</a>]
+                </td>
+                <td>
+                    <select style="min-width: 100%;" id="ml_main_col_template_details_type">
+                        <option selected value="single-record">Single Record</option>
+                        <option value="list-sub-assigned-contacts">List Sub-Assigned Contacts</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
                 <td style="vertical-align: middle;">Add a D.T field to the form</td>
                 <td>
                     <select style="min-width: 80%;" id="ml_main_col_template_details_fields">
@@ -469,16 +481,6 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
                 </td>
                 <td>
                     <input type="checkbox" id="ml_main_col_template_details_send_submission_notifications"
-                           value=""/>
-                </td>
-            </tr>
-            <tr>
-                <td style="vertical-align: middle;">List Sub-Assigned Contacts [<a href="#" class="ml-templates-docs"
-                                                                                      data-title="ml_templates_right_docs_list_sub_assigned_contacts_title"
-                                                                                      data-content="ml_templates_right_docs_list_sub_assigned_contacts_content">&#63;</a>]
-                </td>
-                <td>
-                    <input type="checkbox" id="ml_main_col_template_details_list_sub_assigned_contacts"
                            value=""/>
                 </td>
             </tr>

--- a/magic-link/magic-link-templates.php
+++ b/magic-link/magic-link-templates.php
@@ -1288,8 +1288,8 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                 </p>
 
                 <?php
-                // Display list of assigned contacts.
-                if ( isset( $this->template['list_sub_assigned_contacts'] ) && $this->template['list_sub_assigned_contacts'] && !empty( $this->post ) ){
+                // Determine if template type list of assigned contacts is to be displayed.
+                if ( isset( $this->template['type'] ) && ( $this->template['type'] == 'list-sub-assigned-contacts' ) && !empty( $this->post ) ){
 
                     // Fetch all assigned posts
                     $assigned_posts = DT_Posts::list_posts( $this->post['post_type'], [


### PR DESCRIPTION
- fixes: #101 
---

- Ability to manually update `Next Schedule Runs` by selecting future dates and times.
- Ability to reset last scheduled run timestamp, by disabling and enabling scheduling.

![Screenshot 2023-05-19 at 14 39 44](https://github.com/DiscipleTools/disciple-tools-bulk-magic-link-sender/assets/19330800/0ea3c22c-e61a-4759-bec2-b1f09a4a24b0)

![Screenshot 2023-05-19 at 14 40 16](https://github.com/DiscipleTools/disciple-tools-bulk-magic-link-sender/assets/19330800/8b2cccdc-3c08-419e-9821-ed6ea14c890b)


- fixes: #107  
---

- Ability to select different template types to be adopted when displaying magic-link form.
- The following types are currently supported:
  - Single Record
  - List Sub-Assigned Contacts

![Screenshot 2023-05-19 at 14 40 42](https://github.com/DiscipleTools/disciple-tools-bulk-magic-link-sender/assets/19330800/02dff1e6-3706-4cb2-bc0e-3c077d7432ee)

![Screenshot 2023-05-19 at 14 41 01](https://github.com/DiscipleTools/disciple-tools-bulk-magic-link-sender/assets/19330800/13df3d9d-daef-4258-9b12-dbcd43d89ea0)
