### PR TITLE
Mark magic link fields as readonly

### DIFF
--- a/admin/js/templates-tab.js
+++ b/admin/js/templates-tab.js
@@ -192,7 +192,7 @@ jQuery(function ($) {
 
       // Reload previously selected fields
       $.each(data['fields'], function (idx, field) {
-        $('.connected-sortable-fields').append(build_new_selected_field_html(field['id'], field['label'], field['type'], field['enabled'], (field['translations'] !== undefined) ? field['translations'] : {}, (field['custom_form_field_type'] !== undefined) ? field['custom_form_field_type'] : 'textfield'));
+        $('.connected-sortable-fields').append(build_new_selected_field_html(field['id'], field['label'], field['type'], field['enabled'], (field['translations'] !== undefined) ? field['translations'] : {}, (field['custom_form_field_type'] !== undefined) ? field['custom_form_field_type'] : 'textfield', field['readonly']));
       });
 
       // Instantiate sortable fields capabilities
@@ -597,14 +597,21 @@ jQuery(function ($) {
     return already_selected;
   }
 
-  function build_new_selected_field_html(field_id, field_label, field_type, field_enabled, field_translations, field_custom_form_type = 'textfield') {
+  function build_new_selected_field_html(field_id, field_label, field_type, field_enabled, field_translations, field_custom_form_type = 'textfield', field_readonly = false) {
 
     // Ensure default field labels are disabled and cannot be overwritten, along with any other field type specific settings.
     let label_disabled_html = '';
     let final_form_custom_field_type_html = '';
+    let field_readonly_html = '';
     switch (field_type) {
       case 'dt' : {
         label_disabled_html = 'disabled';
+        field_readonly_html = `
+            <select id="ml_main_col_selected_fields_sortable_field_readonly">
+                <option value="" ${!field_readonly ? 'selected':''}>Editable</option>
+                <option value="readonly" ${field_readonly ? 'selected':''}>Readonly</option>
+            </select>
+        `;
         break;
       }
       case 'custom' : {
@@ -636,6 +643,7 @@ jQuery(function ($) {
                                type="text" value="${field_label}" ${label_disabled_html}/>
                     </td>
                     <td style="text-align: right;">
+                        ${field_readonly_html}
                         ${final_form_custom_field_type_html}
                         ${build_translation_button_html(field_id, field_label, field_type, field_translations, label_disabled_html)}
                         <button type="submit" class="button float-right connected-sortable-fields-remove-but">
@@ -733,6 +741,7 @@ jQuery(function ($) {
       let id = $(field_div).find('#ml_main_col_selected_fields_sortable_field_id').val();
       let type = $(field_div).find('#ml_main_col_selected_fields_sortable_field_type').val();
       let enabled = $(field_div).find('#ml_main_col_selected_fields_sortable_field_enabled').prop('checked');
+      let readonly = $(field_div).find('#ml_main_col_selected_fields_sortable_field_readonly').val() === 'readonly';
       let label = $(field_div).find('#ml_main_col_selected_fields_sortable_field_label').val();
       let translations = (type === 'dt') ? {} : JSON.parse(decodeURIComponent($(field_div).find('.connected-sortable-fields-translate-but').data('field_translations')));
       let custom_form_field_type = (type === 'custom') ? $(field_div).find('#ml_main_col_selected_fields_sortable_form_custom_field_type').val() : '';
@@ -741,6 +750,7 @@ jQuery(function ($) {
         'id': id,
         'type': type,
         'enabled': enabled,
+        'readonly': readonly,
         'label': label,
         'translations': translations,
         'custom_form_field_type': custom_form_field_type

--- a/magic-link/magic-link-templates.php
+++ b/magic-link/magic-link-templates.php
@@ -1464,6 +1464,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                                             // Capture rendered field html
                                             ob_start();
                                             $this->post_field_settings[$field['id']]['custom_display'] = false;
+                                            $this->post_field_settings[$field['id']]['readonly'] = $field['readonly'];
                                             render_field_for_display( $field['id'], $this->post_field_settings, $this->post, true );
                                             $rendered_field_html = ob_get_contents();
                                             ob_end_clean();


### PR DESCRIPTION
When creating magic link templates, sometimes you want a user to see some fields but not be able to edit them. To do that, this PR adds the ability to mark each field in a magic link template as editable or readonly so that the magic link will disable fields that are readonly.