### PR TITLE
Configure how many comments to show on magic link

### DIFF
--- a/admin/js/templates-tab.js
+++ b/admin/js/templates-tab.js
@@ -219,7 +219,7 @@ jQuery(function ($) {
     title_translations: {},
     type: 'single-record',
     custom_fields: '',
-    show_recent_comments: false,
+    show_recent_comments: 0,
     send_submission_notifications: true,
     support_creating_new_items: false // Linked to type & only enabled for list-sub-assigned-contacts type.
   }, callback = function () {
@@ -270,7 +270,7 @@ jQuery(function ($) {
         $('#ml_main_col_template_details_type').val(data.type);
         $('.template-title-translate-but-label').text(Object.keys(data.title_translations).length);
         $('#ml_main_col_template_details_custom_fields').val(data.custom_fields);
-        $('#ml_main_col_template_details_show_recent_comments').prop('checked', data.show_recent_comments);
+        $('#ml_main_col_template_details_show_recent_comments').val(data.show_recent_comments === true ? 2 : Number(data.show_recent_comments));
         $('#ml_main_col_template_details_send_submission_notifications').prop('checked', data.send_submission_notifications);
         $(supports_create).prop('checked', data.support_creating_new_items);
         $(supports_create).prop( 'disabled', ( data.type === 'single-record' ) );
@@ -286,7 +286,7 @@ jQuery(function ($) {
       $('#ml_main_col_template_details_type').val(data.type);
       $('.template-title-translate-but-label').text(Object.keys(data.title_translations).length);
       $('#ml_main_col_template_details_custom_fields').val(data.custom_fields);
-      $('#ml_main_col_template_details_show_recent_comments').prop('checked', data.show_recent_comments);
+      $('#ml_main_col_template_details_show_recent_comments').val(data.show_recent_comments === true ? 2 : Number(data.show_recent_comments))
       $('#ml_main_col_template_details_send_submission_notifications').prop('checked', data.send_submission_notifications);
       $(supports_create).prop('checked', data.support_creating_new_items);
       $(supports_create).prop( 'disabled', ( data.type === 'single-record' ) );
@@ -692,7 +692,7 @@ jQuery(function ($) {
     let title = $('#ml_main_col_template_details_title').val();
     let title_translations = JSON.parse(decodeURIComponent($('#ml_main_col_template_details_title_translate_but').data('field_translations')));
     let type = $('#ml_main_col_template_details_type').val();
-    let show_recent_comments = $('#ml_main_col_template_details_show_recent_comments').prop('checked');
+    let show_recent_comments = $('#ml_main_col_template_details_show_recent_comments').val();
     let send_submission_notifications = $('#ml_main_col_template_details_send_submission_notifications').prop('checked');
     let support_creating_new_items = $('#ml_main_col_template_details_supports_create').prop('checked');
     let message = $('#ml_main_col_msg_textarea').val();
@@ -732,7 +732,7 @@ jQuery(function ($) {
         'title': title,
         'title_translations': title_translations,
         'type': type,
-        'show_recent_comments': show_recent_comments,
+        'show_recent_comments': Number(show_recent_comments),
         'send_submission_notifications': send_submission_notifications,
         'support_creating_new_items': support_creating_new_items,
         'message': message,

--- a/admin/js/templates-tab.js
+++ b/admin/js/templates-tab.js
@@ -192,7 +192,7 @@ jQuery(function ($) {
 
       // Reload previously selected fields
       $.each(data['fields'], function (idx, field) {
-        $('.connected-sortable-fields').append(build_new_selected_field_html(field['id'], field['label'], field['type'], field['enabled'], (field['translations'] !== undefined) ? field['translations'] : {}, (field['custom_form_field_type'] !== undefined) ? field['custom_form_field_type'] : 'textfield'));
+        $('.connected-sortable-fields').append(build_new_selected_field_html(field['id'], field['label'], field['type'], field['enabled'], (field['translations'] !== undefined) ? field['translations'] : {}, (field['custom_form_field_type'] !== undefined) ? field['custom_form_field_type'] : 'textfield', field['readonly']));
       });
 
       // Instantiate sortable fields capabilities
@@ -597,14 +597,21 @@ jQuery(function ($) {
     return already_selected;
   }
 
-  function build_new_selected_field_html(field_id, field_label, field_type, field_enabled, field_translations, field_custom_form_type = 'textfield') {
+  function build_new_selected_field_html(field_id, field_label, field_type, field_enabled, field_translations, field_custom_form_type = 'textfield', field_readonly = false) {
 
     // Ensure default field labels are disabled and cannot be overwritten, along with any other field type specific settings.
     let label_disabled_html = '';
     let final_form_custom_field_type_html = '';
+    let field_readonly_html = '';
     switch (field_type) {
       case 'dt' : {
         label_disabled_html = 'disabled';
+        field_readonly_html = `
+            <select id="ml_main_col_selected_fields_sortable_field_readonly">
+                <option value="" ${!field_readonly ? 'selected':''}>Editable</option>
+                <option value="readonly" ${field_readonly ? 'selected':''}>Readonly</option>
+            </select>
+        `;
         break;
       }
       case 'custom' : {
@@ -636,6 +643,7 @@ jQuery(function ($) {
                                type="text" value="${field_label}" ${label_disabled_html}/>
                     </td>
                     <td style="text-align: right;">
+                        ${field_readonly_html}
                         ${final_form_custom_field_type_html}
                         ${build_translation_button_html(field_id, field_label, field_type, field_translations, label_disabled_html)}
                         <button type="submit" class="button float-right connected-sortable-fields-remove-but">
@@ -733,6 +741,7 @@ jQuery(function ($) {
       let id = $(field_div).find('#ml_main_col_selected_fields_sortable_field_id').val();
       let type = $(field_div).find('#ml_main_col_selected_fields_sortable_field_type').val();
       let enabled = $(field_div).find('#ml_main_col_selected_fields_sortable_field_enabled').prop('checked');
+      let readonly = $(field_div).find('#ml_main_col_selected_fields_sortable_field_readonly').val() === 'readonly';
       let label = $(field_div).find('#ml_main_col_selected_fields_sortable_field_label').val();
       let translations = (type === 'dt') ? {} : JSON.parse(decodeURIComponent($(field_div).find('.connected-sortable-fields-translate-but').data('field_translations')));
       let custom_form_field_type = (type === 'custom') ? $(field_div).find('#ml_main_col_selected_fields_sortable_form_custom_field_type').val() : '';
@@ -741,6 +750,7 @@ jQuery(function ($) {
         'id': id,
         'type': type,
         'enabled': enabled,
+        'readonly': readonly,
         'label': label,
         'translations': translations,
         'custom_form_field_type': custom_form_field_type

--- a/admin/templates-tab.php
+++ b/admin/templates-tab.php
@@ -467,7 +467,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
             <tr>
                 <td style="vertical-align: middle;">Show Recent Comments</td>
                 <td>
-                    <input type="checkbox" id="ml_main_col_template_details_show_recent_comments"
+                    <input type="number" id="ml_main_col_template_details_show_recent_comments"
                            value=""/>
                 </td>
             </tr>

--- a/admin/templates-tab.php
+++ b/admin/templates-tab.php
@@ -465,7 +465,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
                 </td>
             </tr>
             <tr>
-                <td style="vertical-align: middle;">Show Recent Comments</td>
+                <td style="vertical-align: middle;">Number for recent comments to show. To disable set the value to 0.</td>
                 <td>
                     <input type="number" id="ml_main_col_template_details_show_recent_comments"
                            value=""/>

--- a/magic-link/magic-link-templates.php
+++ b/magic-link/magic-link-templates.php
@@ -1464,6 +1464,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                                             // Capture rendered field html
                                             ob_start();
                                             $this->post_field_settings[$field['id']]['custom_display'] = false;
+                                            $this->post_field_settings[$field['id']]['readonly'] = $field['readonly'];
                                             render_field_for_display( $field['id'], $this->post_field_settings, $this->post, true );
                                             $rendered_field_html = ob_get_contents();
                                             ob_end_clean();

--- a/magic-link/magic-link-templates.php
+++ b/magic-link/magic-link-templates.php
@@ -1537,7 +1537,8 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
 
                             // If requested, display recent comments
                             if ( $this->template['show_recent_comments'] ) {
-                                $recent_comments = DT_Posts::get_post_comments( $this->post['post_type'], $this->post['ID'], false, 'all', [ 'number' => 2 ] );
+                                $comment_count = is_bool( $this->template['show_recent_comments'] ) ? 2 : intval( $this->template['show_recent_comments'] );
+                                $recent_comments = DT_Posts::get_post_comments( $this->post['post_type'], $this->post['ID'], false, 'all', [ 'number' => $comment_count ] );
                                 foreach ( $recent_comments['comments'] ?? [] as $comment ) {
                                     ?>
                                     <tr class="dt-comment-tr">


### PR DESCRIPTION
To allow the adjustment of how many comments show on a magic link, this changes the checkbox for `show_recent_comments` to a number input. The default is set to 2 if the value is a boolean `true`. Otherwise it is saved as an integer. When set to zero, that falsy value will act the same as being unchecked previously. 