### PR TITLE
Fix errors saving magic link template fields

### DIFF
--- a/magic-link/magic-link-templates.php
+++ b/magic-link/magic-link-templates.php
@@ -1129,6 +1129,10 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                         let field_template_type = jQuery(tr).find('#form_content_table_field_template_type').val();
                         let field_meta = jQuery(tr).find('#form_content_table_field_meta');
 
+                        let template_fields = jsObject.template.fields.filter(f => f.id === field_id);
+                        if (template_fields && template_fields.length && template_fields[0].readonly) {
+                            return;
+                        }
                         let selector = '#' + field_id;
                         if (field_template_type === 'dt') {
                             switch (field_type) {

--- a/magic-link/magic-link-templates.php
+++ b/magic-link/magic-link-templates.php
@@ -803,7 +803,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                                  * Load
                                  */
 
-                                // If available, load previous post record tags
+                                    // If available, load previous post record tags
                                 let typeahead_tags = window.Typeahead[typeahead_tags_field_input];
                                 let post_tags = jsObject['post'][field_id];
                                 if ((post_tags !== undefined) && typeahead_tags) {
@@ -1466,7 +1466,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                                             'communication_channel',
                                             'location',
                                             'location_meta'
-                                    ] ) ) {
+                                        ] ) ) {
                                         continue;
                                     }
 
@@ -1640,7 +1640,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
         }
 
         // Sanitize and fetch user id
-        $params = dt_recursive_sanitize_array( $params );
+//        $params = dt_recursive_sanitize_array( $params );
 
         // Update logged-in user state, if required
         if ( !is_user_logged_in() ){
@@ -1655,13 +1655,16 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                 case 'number':
                 case 'textarea':
                 case 'text':
-                case 'key_select':
                 case 'date':
                 case 'boolean':
+                    $field = dt_recursive_sanitize_array( $field );
                     $updates[$field['id']] = $field['value'];
                     break;
-
+                case 'key_select':
+                    $updates[$field['id']] = wp_slash( $field['value'] );
+                    break;
                 case 'communication_channel':
+                    $field = dt_recursive_sanitize_array( $field );
                     $updates[$field['id']] = [];
 
                     // First, capture additions and updates
@@ -1686,6 +1689,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                     break;
 
                 case 'multi_select':
+                    $field = dt_recursive_sanitize_array( $field );
                     $options = [];
                     foreach ( $field['value'] ?? [] as $option ){
                         $entry = [];
@@ -1703,6 +1707,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                     break;
 
                 case 'location':
+                    $field = dt_recursive_sanitize_array( $field );
                     $locations = [];
                     foreach ( $field['value'] ?? [] as $location ){
                         $entry = [];
@@ -1727,6 +1732,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                     break;
 
                 case 'location_meta':
+                    $field = dt_recursive_sanitize_array( $field );
                     $locations = [];
 
                     // Capture selected location, if available; or prepare shape
@@ -1754,6 +1760,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                     break;
 
                 case 'tags':
+                    $field = dt_recursive_sanitize_array( $field );
                     $tags = [];
                     foreach ( $field['value'] ?? [] as $tag ){
                         $entry = [];
@@ -1809,6 +1816,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
 
         // Next, any identified custom fields, are to be added as comments
         foreach ( $params['fields']['custom'] ?? [] as $field ) {
+            $field = dt_recursive_sanitize_array( $field );
             if ( ! empty( $field['value'] ) ) {
                 $updated_comment = DT_Posts::add_post_comment( $updated_post['post_type'], $updated_post['ID'], $field['value'], 'comment', [], false );
                 if ( empty( $updated_comment ) || is_wp_error( $updated_comment ) ) {

--- a/magic-link/magic-link-templates.php
+++ b/magic-link/magic-link-templates.php
@@ -1470,7 +1470,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                                             'communication_channel',
                                             'location',
                                             'location_meta'
-                                        ] ) ) {
+                                    ] ) ) {
                                         continue;
                                     }
 
@@ -1665,7 +1665,7 @@ class Disciple_Tools_Magic_Links_Templates extends DT_Magic_Url_Base {
                     $updates[$field['id']] = $field['value'];
                     break;
                 case 'key_select':
-                    $updates[$field['id']] = wp_slash( $field['value'] );
+                    $updates[$field['id']] = $field['value'];
                     break;
                 case 'communication_channel':
                     $field = dt_recursive_sanitize_array( $field );


### PR DESCRIPTION
This fixes two issues:
1. Don't send readonly fields to API to be saved
2. Fix encoding error for age field (and other `key_select` fields)

The first is self-explanatory.

To expand on the second, I found that when the `age` field was used in a magic link, the value being saved would be something like `&lt;40` instead of the correct `<40`. This is because all fields were being sanitized like they were open text fields. To alleviate that, I moved the sanitize function inside of the switch statement depending on each field type. Those that are open fields for direct user input are sanitized and others are not. This fixed the issue with `key_select` while still encoding open input fields.