### PR TITLE
Layout-list-details filters and UI improvements

### DIFF
--- a/assets/layout-list-detail.css
+++ b/assets/layout-list-detail.css
@@ -326,9 +326,6 @@ code { display: block !important; }
 }
 #detail-content dt-tile {
     --dt-tile-margin: 1rem 0rem;
-    &#all-fields > * {
-        margin-block-end: 1rem;
-    }
 }
 #detail footer {
     background: #fff;
@@ -372,12 +369,15 @@ code { display: block !important; }
 /* ===== Snackbar ===== */
 #snackbar-area {
     position: fixed;
-    bottom: 1rem;
+    inset-block-end: 1rem;
     padding: 10px;
-    right: 1rem;
+    inset-inline-end: 1rem;
     width: 350px;
     z-index: 1000;
     max-height: 80%;
+    &:empty {
+        display: none;
+    }
 }
 .snackbar-item {
     backdrop-filter: blur(7px);

--- a/assets/layout-list-detail.css
+++ b/assets/layout-list-detail.css
@@ -27,6 +27,7 @@ code { display: block !important; }
 /* ===== List Panel ===== */
 #list {
     --header-height: 3rem;
+    --header-z-index: 5;
     --search-margin-block: 1rem;
     --search-border-width: 2px;
     --search-input-height: 2.5rem;
@@ -65,7 +66,7 @@ code { display: block !important; }
     padding-block-start: 1rem;
     position: absolute;
     width: 100%;
-    z-index: 1;
+    z-index: var(--header-z-index);
 }
 
 #list > header > h1 {
@@ -156,7 +157,7 @@ code { display: block !important; }
     display: grid;
     grid-template-rows: var(--search-height) 1fr;
     transition: grid-template-rows 500ms;
-    z-index: 1;
+    z-index: var(--header-z-index);
     position: absolute;
     width: 100%;
     top: var(--header-height);
@@ -167,6 +168,25 @@ code { display: block !important; }
 
 #search-filter:has(.filters.hidden) {
     grid-template-rows: var(--search-height) 0fr;
+
+    & + #filter-backdrop {
+        display: none;
+        opacity: 0;
+    }
+}
+#filter-backdrop {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: calc(var(--header-z-index) - 1);
+    display: block;
+    opacity: 1;
+    transition: opacity 0.5s ease, display 0.5s ease allow-discrete;
+}
+@starting-style {
+    #filter-backdrop {
+        opacity: 0;
+    }
 }
 
 #search-bar,

--- a/assets/layout-list-detail.css
+++ b/assets/layout-list-detail.css
@@ -130,6 +130,27 @@ code { display: block !important; }
     opacity: 1;
 }
 
+#list .items:has(+ #fab-container) {
+    padding-bottom: 5rem;
+}
+
+
+/* ===== FAB ====== */
+#fab-container {
+    position: absolute;
+    inset-block-end: 2rem;
+    inset-inline-end: 2rem;
+
+    #fab-button {
+        color: var(--text-color-inverse);
+        background-color: var(--success-color);
+        padding: 1rem;
+        font-size: 1.5rem;
+        border-radius: 50%;
+        box-shadow: var(--shadow-1);
+    }
+}
+
 /* ===== Search & Filter ===== */
 #search-filter {
     display: grid;

--- a/assets/layout-list-detail.css
+++ b/assets/layout-list-detail.css
@@ -102,19 +102,21 @@ code { display: block !important; }
     transition: opacity .5s ease;
 }
 #list .items li a {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
     column-gap: 0.5rem;
-    align-items: center;
     width: 100%;
     color: inherit;
     text-decoration: none;
     padding: 1rem;
 
-    .post-title {
-        flex-grow: 1;
+    .post-title, .post-meta {
+        grid-column-start: 2;
     }
 
-    .post-id, .post-updated-date {
+    .post-id,
+    .post-updated-date,
+    .post-meta {
         color: var(--inactive-color);
         font-size: 0.75rem;
     }
@@ -171,26 +173,32 @@ code { display: block !important; }
     height: var(--search-input-height);
 }
 
-#search-bar button.clear-button {
-    position: absolute;
-    inset-inline-end: 3.25rem;
-    top: calc(var(--search-margin-block) + var(--search-border-width));
-    border: 0;
-    background-color: transparent;
-    height: var(--search-input-height);
-}
-
+#search-bar button.clear-button,
 #search-bar button.filter-button {
     position: absolute;
-    inset-inline-end: 1.25rem;
     top: calc(var(--search-margin-block) + var(--search-border-width));
     border: 0;
     background-color: transparent;
     height: var(--search-input-height);
+    font-size: 1.75rem;
+}
+#search-bar button.clear-button {
+    inset-inline-end: 3.25rem;
+}
+#search-bar button.filter-button {
+    inset-inline-end: 1.25rem;
+}
+#search-bar #results-count {
+    position: absolute;
+    bottom: 0.75rem;
+    left: var(--search-margin-block);
+    font-size: 0.75rem;
 }
 
 .filters .container {
-    padding: 1rem;
+    padding: 0 1rem 1rem;
+
+    h3 { margin-block-start: 1rem; }
 }
 
 .filters {
@@ -297,6 +305,9 @@ code { display: block !important; }
 }
 #detail-content dt-tile {
     --dt-tile-margin: 1rem 0rem;
+    &#all-fields > * {
+        margin-block-end: 1rem;
+    }
 }
 #detail footer {
     background: #fff;

--- a/assets/layout-list-detail.js
+++ b/assets/layout-list-detail.js
@@ -240,7 +240,7 @@ function saveItem(event) {
         listItems.set(json.post.ID.toString(), json.post);
 
         if (id === "0") {
-          loadListItems();
+          searchData();
         } else {
           // update list item
           const itemEl = document.getElementById(`item-${json.post.ID}`);

--- a/assets/layout-list-detail.js
+++ b/assets/layout-list-detail.js
@@ -30,6 +30,12 @@ function loadPostDetail(id) {
 
   // insert templated content into detail panel
   detailContainer.replaceChildren(content);
+  detailContainer.dispatchEvent(new CustomEvent('dt:post-load', {
+    detail: {
+      id,
+      post: item,
+    },
+  }));
 
   // open detail panel
   document.getElementById('list').classList.remove('is-expanded');
@@ -56,6 +62,9 @@ function loadListItems(posts) {
     posts = jsObject.items.posts;
   }
 
+  const resultCount = document.getElementById('results-count-number');
+  resultCount.innerText = posts.length;
+
   const itemList = document.getElementById('list-items');
   itemList.replaceChildren([]);
   const itemTemplate = document.getElementById('list-item-template').content;
@@ -65,6 +74,10 @@ function loadListItems(posts) {
     itemEl.querySelector('li').id = `item-${item.ID}`;
     populateListItemTemplate(itemEl, item);
     itemList.append(itemEl);
+    if (!listItems.has(item.ID.toString())) {
+      listItems.set(item.ID.toString(), item);
+    }
+
   }
 
 }
@@ -78,6 +91,10 @@ function populateListItemTemplate(itemEl, item) {
   itemEl.querySelector('.post-updated-date').innerText = window.SHAREDFUNCTIONS.formatDate(
     item.last_modified?.timestamp
   );
+
+  if (item.meta) {
+    itemEl.querySelector('.post-meta').innerText = item.meta;
+  }
 }
 
 /**
@@ -98,6 +115,15 @@ function setInputValues(parent, post) {
     const postValue = post[name];
 
     switch (tagName) {
+      case 'dt-connection':
+        element.value = DtWebComponents.ComponentService.convertApiValue(tagName, postValue);
+        break;
+      case 'dt-location':
+        element.value = postValue?.map(val => ({
+          ...val,
+          id: val.id.toString(),
+        }));
+        break;
       case 'dt-date':
         if (postValue && postValue.timestamp) {
           const date = new Date(postValue.timestamp * 1000);
@@ -167,8 +193,7 @@ function saveItem(event) {
     const field_id = el.name;
     const type = el.dataset.type;
 
-    // const value = DtWebComponents.ComponentService.convertValue(el.localName, el.value);
-    const value = window.WebComponentServices.ComponentService.convertValue(el.localName, el.value);
+    const value = DtWebComponents.ComponentService.convertValue(el.localName, el.value);
     const fieldType = type === 'custom' ? 'custom' : 'dt';
     payload['fields'][fieldType].push({
       id: field_id,
@@ -177,7 +202,7 @@ function saveItem(event) {
     });
   });
 
-  const url = jsObject.root + jsObject.parts.root + '/v1/' + jsObject.parts.type + '/update';
+  const url = window.apiRoot + '/update';
   fetch(url,{
     method: "POST", // *GET, POST, PUT, DELETE, etc.
     headers: {
@@ -286,12 +311,30 @@ const searchData = () => {
     post_type: jsObject.template.record_type,
     text: text,
     sort: document.querySelector('input[name="sort"]:checked').value,
+    fields: {},
+  }
+
+  // Get filter values
+  const filterContainer = document.querySelector('.filters .container');
+  const filterComponents = Array.from(filterContainer.children).filter(el =>
+    el.tagName.toLowerCase().startsWith('dt-')
+  );
+  for(const el of filterComponents) {
+    switch (el.localName) {
+      case 'dt-multi-select':
+      case 'dt-multi-select-button-group':
+        payload.fields[el.name] = (el.value || []).filter(x => !x.startsWith('-'));
+        break;
+      default:
+        payload.fields[el.name] = DtWebComponents.ComponentService.convertValue(el.localName, el.value)
+        break;
+    }
   }
 
   let temp_spinner = document.getElementById('temp-spinner');
   temp_spinner.setAttribute('class', 'loading-spinner active');
 
-  const url = jsObject.root + jsObject.parts.root + '/v1/' + jsObject.parts.type + '/sort_post';
+  const url = window.apiRoot + '/sort_post';
 
   fetch(url,{
     method: "POST",
@@ -345,7 +388,7 @@ function setComments(commentsTile, id) {
     comment_count: 2,
   }
 
-  const commentURL = jsObject.root + jsObject.parts.root + '/v1/' + jsObject.parts.type + '/post';
+  const commentURL = window.apiRoot + '/post';
   const comments = commentsTile.querySelectorAll('.activity-block, .action-block');
   if (comments.length) {
     for (const comment of comments) {
@@ -361,11 +404,14 @@ function setComments(commentsTile, id) {
     body: JSON.stringify(payload),
   })
     .then((response) => {
-      console.log(response);
+      // console.log(response);
       return response.json();
     })
     .then((json) => {
       for (const val of json['comments']['comments']) {
+        if (!val['comment_content']) {
+          continue;
+        }
         const actionBlock = document.createElement('div');
         actionBlock.className = "action-block";
 
@@ -392,7 +438,9 @@ function setComments(commentsTile, id) {
         commentId.className = "comment-bubble " + val['comment_ID'];
         commentId.setAttribute("data-comment-id", val['comment_ID']);
         commentText.setAttribute("title", val['comment_date']);
-        commentText.innerText = val['comment_content'];
+        const decoder = document.createElement('div');
+        decoder.innerHTML = val['comment_content'];
+        commentText.innerText = decoder.textContent;
 
         activityBlock.appendChild(commentHeader);
         activityBlock.appendChild(commentContent);
@@ -408,40 +456,60 @@ function setComments(commentsTile, id) {
     });
 }
 
-  function submitComment(id) {
+function submitComment(id) {
 
-    const textArea = document.getElementById('comments-text-area');
-    if (!textArea.value) {
-      return false;
-    }
-
-    let payload = {
-      action: 'post',
-      parts: jsObject.parts,
-      sys_type: jsObject.sys_type,
-      post_id: id,
-      post_type: jsObject.template.record_type,
-      comment: textArea.value,
-    }
-
-    const url = jsObject.root + jsObject.parts.root + '/v1/' + jsObject.parts.type + '/comment';
-
-    fetch(url,{
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        "X-WP-Nonce": jsObject.nonce,
-      },
-      body: JSON.stringify(payload),
-    })
-      .then((response) => {
-        textArea.value = '';
-        const commentTile = document.getElementById('comments-tile');
-        setComments(commentTile, id);
-        return response.json();
-      })
-      .catch((reason) => {
-        console.log("reason:");
-        console.log(reason);
-      });
+  const textArea = document.getElementById('comments-text-area');
+  if (!textArea.value) {
+    return false;
   }
+
+  let payload = {
+    action: 'post',
+    parts: jsObject.parts,
+    sys_type: jsObject.sys_type,
+    post_id: id,
+    post_type: jsObject.template.record_type,
+    comment: textArea.value,
+  }
+
+  const url = window.apiRoot + '/comment';
+
+  fetch(url,{
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "X-WP-Nonce": jsObject.nonce,
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => {
+      textArea.value = '';
+      const commentTile = document.getElementById('comments-tile');
+      setComments(commentTile, id);
+      return response.json();
+    })
+    .catch((reason) => {
+      console.log("reason:");
+      console.log(reason);
+    });
+}
+
+function attachFilterListeners() {
+  const filterContainer = document.querySelector('.filters .container');
+  if (!filterContainer) return;
+
+
+  const filterComponents = Array.from(filterContainer.children).filter(el =>
+    el.tagName.toLowerCase().startsWith('dt-')
+  );
+  filterComponents.forEach(element => {
+    element.addEventListener('change', searchChange);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', attachFilterListeners);
+
+window.addEventListener('load', () => {
+  const apiVersion = jsObject.parts.version ?? 'v1';
+  window.apiRoot = jsObject.root + jsObject.parts.root + '/' + apiVersion + '/' + jsObject.parts.type;
+});

--- a/assets/layout-list-detail.js
+++ b/assets/layout-list-detail.js
@@ -173,7 +173,7 @@ function saveItem(event) {
   };
   formdata.forEach((value, key) => (data.form[key] = value));
   Array.from(form.elements).forEach((el) => {
-    if (el.localName.startsWith('dt-')) {
+    if (el.localName.startsWith('dt-') && el.name) {
       data.el[el.name] = el.value;
     }
   });

--- a/assets/layout-list-detail.js
+++ b/assets/layout-list-detail.js
@@ -3,38 +3,49 @@
  * @param id
  */
 function loadPostDetail(id) {
-  const item = listItems.get(id.toString());
 
   const detailTitle = document.getElementById('detail-title');
   const detailPostId = document.getElementById('detail-title-post-id');
   const detailTemplate = document.getElementById('post-detail-template').content;
   const detailContainer = document.getElementById('detail-content');
 
-  // Set detail title
-  detailTitle.innerText = item.name;
-  detailPostId.innerText = `(#${item.ID})`;
-
   // clone detail template
   const content = detailTemplate.cloneNode(true);
-
-  // set value of all inputs in the template
-  content.getElementById('post-id').value = id;
-  setInputValues(content, item);
-
-  const button = content.getElementById('comment-button');
-  button.addEventListener('click', () => {
-    submitComment(id);
-  });
   const commentTile = content.getElementById('comments-tile');
-  setComments(commentTile, item.ID);
+
+  const postLoadEventDetail = { id };
+
+  if (id > 0) {
+    const item = listItems.get(id.toString());
+    postLoadEventDetail.post = item;
+
+    // Set detail title
+    detailTitle.innerText = item.name;
+    detailPostId.innerText = `(#${item.ID})`;
+
+    // set value of all inputs in the template
+    content.getElementById('post-id').value = id;
+    setInputValues(content, item);
+
+    const button = content.getElementById('comment-button');
+    button.addEventListener('click', () => {
+      submitComment(id);
+    });
+    setComments(commentTile, item.ID);
+  } else {
+    detailTitle.innerText = jsObject.translations.new_record;
+    detailPostId.innerText = ``;
+
+    content.getElementById('post-id').value = id;
+
+    // hide comment container
+    commentTile.style.display = 'none';
+  }
 
   // insert templated content into detail panel
   detailContainer.replaceChildren(content);
   detailContainer.dispatchEvent(new CustomEvent('dt:post-load', {
-    detail: {
-      id,
-      post: item,
-    },
+    detail: postLoadEventDetail,
   }));
 
   // open detail panel
@@ -223,12 +234,18 @@ function saveItem(event) {
         const idx = jsObject.items.posts.findIndex((i) => i.ID === json.post.ID);
         if (idx > -1) {
           jsObject.items.posts[idx] = json.post;
+        } else {
+          jsObject.items.posts.splice(0, 0, json.post);
         }
         listItems.set(json.post.ID.toString(), json.post);
 
-        // update list item
-        const itemEl = document.getElementById(`item-${json.post.ID}`);
-        populateListItemTemplate(itemEl, json.post);
+        if (id === "0") {
+          loadListItems();
+        } else {
+          // update list item
+          const itemEl = document.getElementById(`item-${json.post.ID}`);
+          populateListItemTemplate(itemEl, json.post);
+        }
 
         // go back to list
         togglePanels();

--- a/magic-link/layouts/list-detail-layout.php
+++ b/magic-link/layouts/list-detail-layout.php
@@ -195,6 +195,11 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
                         <?php
                         if ( !isset( $post_field_settings[ $filter['id'] ]['default']['blank'] ) ) {
                             $post_field_settings[ $filter['id'] ]['default']['blank'] = [ 'label' => '(blank)' ];
+                            if ( isset( $filter['display'] ) ) {
+                                $post_field_settings[$filter['id']]['display'] = $filter['display'];
+                            } else {
+                                unset( $post_field_settings[$filter['id']]['display'] );
+                            }
                         }
                         ?>
                         <?php switch ( $filter['type'] ) {
@@ -403,6 +408,8 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
                 <?php $this->list_header(); ?>
 
                 <?php $this->list_filters(); ?>
+
+                <div id="filter-backdrop" class="hidden" onclick="toggleFilters()"></div>
 
                 <ul id="list-items" class="items"></ul>
 

--- a/magic-link/layouts/list-detail-layout.php
+++ b/magic-link/layouts/list-detail-layout.php
@@ -28,6 +28,7 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
     ];
 
     public $filter_options = [];
+    public $allow_new_records = false;
 
     public function __construct( $template = null, $post = null, $link_obj = null ) {
 
@@ -39,6 +40,15 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
         $this->template         = $template;
         $this->post             = $post;
         $this->link_obj         = $link_obj;
+
+        if ( isset( $template['supports_create'] ) && boolval( $template['supports_create'] ) ) {
+            $this->allow_new_records = true;
+        } else if ( isset( $link_obj ) &&
+                property_exists( $link_obj, 'type_config' ) &&
+                property_exists( $link_obj->type_config, 'supports_create' ) &&
+                $link_obj->type_config->supports_create ) {
+            $this->allow_new_records = true;
+        }
     }
 
     public function wp_enqueue_scripts(): void
@@ -104,6 +114,7 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
                 'template'                => $this->template,
                 'fieldSettings' => $localized_template_field_settings, //todo: should be for sub-type
                 'translations'            => [
+                    'new_record' => __( 'New Record', 'disciple_tools' ),
                     'regions_of_focus' => __( 'Regions of Focus', 'disciple_tools' ),
                     'all_locations'    => __( 'All Locations', 'disciple_tools' ),
                     'update_success' => __( 'Update Successful!', 'disciple_tools' ),
@@ -364,6 +375,13 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
                 <?php $this->list_filters(); ?>
 
                 <ul id="list-items" class="items"></ul>
+
+                <?php if ( $this->allow_new_records ): ?>
+                <div id="fab-container">
+                    <button id="fab-button" class="fab-button mdi mdi-plus" onclick="loadPostDetail(0)"></button>
+                </div>
+                <?php endif; ?>
+
                 <div id="spinner-div" style="justify-content: center; display: flex;">
                     <span id="temp-spinner" class="loading-spinner inactive" style="margin: 0; position: absolute; top: 50%; -ms-transform: translateY(-50%); transform: translateY(-50%); height: 100px; width: 100px; z-index: 100;"></span>
                 </div>

--- a/magic-link/layouts/list-detail-layout.php
+++ b/magic-link/layouts/list-detail-layout.php
@@ -168,13 +168,13 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
                 <button class="filter-button mdi mdi-filter-variant" onclick="toggleFilters()"></button>
 
                 <div id="results-count">
-                    <span id="results-count-number">0</span> <?php esc_html_e('Records', 'disciple_tools'); ?>
+                    <span id="results-count-number">0</span> <?php esc_html_e( 'Records', 'disciple_tools' ); ?>
                 </div>
             </div>
             <div class="filters hidden">
                 <div class="container">
                     <?php if ( is_array( $this->sort_options ) && !empty( $this->sort_options ) ): ?>
-                    <h3><?php esc_html_e('Sort', 'disciple_tools'); ?></h3>
+                    <h3><?php esc_html_e( 'Sort', 'disciple_tools' ); ?></h3>
                         <?php foreach ( $this->sort_options as $option ): ?>
                             <label>
                                 <input type="radio"
@@ -190,19 +190,19 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
                     <?php endif; ?>
 
                     <?php if ( is_array( $this->filter_options ) && !empty( $this->filter_options ) ): ?>
-                        <h3><?php esc_html_e('Filter', 'disciple_tools'); ?></h3>
+                        <h3><?php esc_html_e( 'Filter', 'disciple_tools' ); ?></h3>
                         <?php foreach ( $this->filter_options as $filter ): ?>
-                        <?php
-                        if ( !isset( $post_field_settings[ $filter['id'] ]['default']['blank'] ) ) {
-                            $post_field_settings[ $filter['id'] ]['default']['blank'] = [ 'label' => '(blank)' ];
-                            if ( isset( $filter['display'] ) ) {
-                                $post_field_settings[$filter['id']]['display'] = $filter['display'];
-                            } else {
-                                unset( $post_field_settings[$filter['id']]['display'] );
+                            <?php
+                            if ( !isset( $post_field_settings[ $filter['id'] ]['default']['blank'] ) ) {
+                                $post_field_settings[ $filter['id'] ]['default']['blank'] = [ 'label' => '(blank)' ];
+                                if ( isset( $filter['display'] ) ) {
+                                    $post_field_settings[$filter['id']]['display'] = $filter['display'];
+                                } else {
+                                    unset( $post_field_settings[$filter['id']]['display'] );
+                                }
                             }
-                        }
-                        ?>
-                        <?php switch ( $filter['type'] ) {
+                            ?>
+                            <?php switch ( $filter['type'] ) {
                                 case 'multi_select':
                                     DT_Components::render_multi_select(
                                         $filter['id'],
@@ -212,7 +212,7 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
                                         ]
                                     );
                                     break;
-                        } ?>
+                            } ?>
                         <?php endforeach; ?>
                     <?php endif; ?>
                 </div>
@@ -323,11 +323,11 @@ class Disciple_Tools_Magic_Links_Layout_List_Detail {
                         'key_select',
                         'multi_select',
                         'number',
-//                        'link',
+                        //                        'link',
                         'communication_channel',
                         'connection',
-//                        'location',
-//                        'location_meta'
+                        //                        'location',
+                        //                        'location_meta'
                     ] ) ) {
                         // Check if function exists
                         if ( function_exists( 'render_field_for_display' ) ) {

--- a/magic-link/magic-links-helper.php
+++ b/magic-link/magic-links-helper.php
@@ -74,12 +74,18 @@ class Disciple_Tools_Magic_Links_Helper
             if ( isset( $fields[$field_key]['icon'] ) && !empty( $fields[$field_key]['icon'] ) ) {
                 $icon = 'icon=' . esc_attr( $fields[$field_key]['icon'] );
             }
+            if ( isset( $fields[$field_key]['post_type'] ) ) {
+                $post_type = 'postType=' . esc_attr( $fields[$field_key]['post_type'] );
+            } else if ( isset( $post ) && isset( $post['post_type'] ) ) {
+                $post_type = 'postType=' . esc_attr( $post['post_type'] );
+            }
 
             $shared_attributes = '
                   id="' . esc_attr( $display_field_id ) . '"
                   name="' . esc_attr( $field_key ) .'"
                   label="' . esc_attr( $fields[$field_key]['name'] ) . '"
                   data-type="' . esc_attr( $field_type ) . '"
+                  ' . esc_html( $post_type ?? '' ) . '
                   ' . esc_html( $icon ) . '
                   ' . esc_html( $required_tag ) . '
                   ' . esc_html( $disabled ) . '


### PR DESCRIPTION
Updates to List-Detail layout which will cascade to Post Connections template or any other magic links using the layout.

- Update components to theme version
- Support configurable filters
- Show result count
- Allow display of extra meta for each list item
- Handle field values: connection & location_grid
- Support non-"v1" API endpoints in js code
- Properly decode HTML entities in comments
- Dispatch event when loading post for attaching other initialization events in other script files
- Add backdrop behind filters list when open. Click backdrop to close filters.
- Support new record creation

<img width="1308" height="470" alt="image" src="https://github.com/user-attachments/assets/9eeb02aa-bfe0-4fec-acdb-cbb1648d949e" />

<img width="1306" height="1804" alt="image" src="https://github.com/user-attachments/assets/1fe3c3bc-4922-4543-83d6-f1b942cc531c" />
