### PR TITLE
Implement preset values for Create Record templates

### DIFF
--- a/admin/js/templates-tab.js
+++ b/admin/js/templates-tab.js
@@ -476,6 +476,7 @@ jQuery(function ($) {
         'boolean',
         'key_select',
         'multi_select',
+        'tags',
         'number',
         'link',
         'communication_channel',

--- a/admin/js/templates-tab.js
+++ b/admin/js/templates-tab.js
@@ -94,6 +94,14 @@ jQuery(function ($) {
     // show record-post-type and connection field only for post-connections
     $('tr.record-post-type-row, tr.connection-field-row').css('display', template_type === 'post-connections' ? 'revert' : 'none');
 
+    // Show/hide Preset Values section
+    if (template_type === 'create-record') {
+      const record_type = $('#ml_main_col_template_details_record_type').val();
+      template_views_preset_values(false, 'slow', {post_type: record_type});
+    } else {
+      template_views_preset_values(true, 'slow');
+    }
+
     if (template_type === 'post-connections') {
       const firstRecordType = $('#ml_main_col_template_details_record_type option:first').val();
       $('#ml_main_col_template_details_record_type').val(firstRecordType);
@@ -114,6 +122,9 @@ jQuery(function ($) {
     // load connections dropdown
     let post_type = $('#templates_management_section_selected_post_type').val();
     refresh_connections_fields_list( post_type, record_type );
+
+    // refresh preset values
+    template_views_preset_values(false, 'slow', {post_type: record_type});
 
     // clear selected fields list since record type change and the existing ones aren't valid now
     template_views_selected_fields(true, 'slow', null, () => {
@@ -159,18 +170,20 @@ jQuery(function ($) {
     // Hide and reset various views back to default state
     template_views_update_and_delete_but(...Array(2), function () {
       template_views_message(...Array(3), function () {
-        template_views_selected_fields(...Array(3), function () {
-          template_views_template_details(...Array(3), function () {
-            template_views_templates_management(...Array(3), function () {
+        template_views_preset_values(...Array(3), function () {
+          template_views_selected_fields(...Array(3), function () {
+            template_views_template_details(...Array(3), function () {
+              template_views_templates_management(...Array(3), function () {
 
-              let post_type_id = $(evt.target).parent().find('#available_post_types_section_post_type_id').val();
+                let post_type_id = $(evt.target).parent().find('#available_post_types_section_post_type_id').val();
 
-              // Capture selected post type id for future reference
-              $('#templates_management_section_selected_post_type').val(post_type_id);
+                // Capture selected post type id for future reference
+                $('#templates_management_section_selected_post_type').val(post_type_id);
 
-              // Roll back to management view only, with corresponding post type templates
-              template_views_templates_management(false, 'slow', {'post_type': post_type_id});
+                // Roll back to management view only, with corresponding post type templates
+                template_views_templates_management(false, 'slow', {'post_type': post_type_id});
 
+              });
             });
           });
         });
@@ -240,6 +253,43 @@ jQuery(function ($) {
     }
   }
 
+  function template_views_preset_values(fade_out = true, fade_speed = 'fast', data = {post_type: 'contacts', preset_values: {}}, callback = function () {
+  }) {
+    let view_preset_values = $('#ml_main_col_preset_values');
+
+    if (fade_out) {
+      view_preset_values.fadeOut(fade_speed, function () {
+        view_preset_values.removeAttr('open');
+        $("#ml_main_col_preset_values_content").empty();
+        callback();
+      });
+
+    } else {
+      const post_type = data.post_type || $('#templates_management_section_selected_post_type').val();
+      const preset_values = data.preset_values || {};
+
+      $.ajax({
+        type: 'GET',
+        url: window.dt_magic_links.dt_get_rendered_fields_url,
+        data: {
+          post_type: post_type,
+          preset_values: JSON.stringify(preset_values)
+        },
+        beforeSend: (xhr) => {
+          xhr.setRequestHeader("X-WP-Nonce", window.dt_magic_links.dt_wp_nonce);
+        },
+        success: function (response) {
+          if (response.success) {
+            $("#ml_main_col_preset_values_content").html(response.html);
+          }
+          view_preset_values.fadeIn(fade_speed, function () {
+            callback();
+          });
+        }
+      });
+    }
+  }
+
   function template_views_template_details(fade_out = true, fade_speed = 'fast', data = {
     id: 'templates_' + moment().unix() + '_magic_key',
     enabled: true,
@@ -247,6 +297,9 @@ jQuery(function ($) {
     title: '',
     title_translations: {},
     type: 'single-record',
+    record_type: 'contacts',
+    connection_fields: [],
+    preset_values: {},
     custom_fields: '',
     show_recent_comments: 0,
     send_submission_notifications: true,
@@ -289,6 +342,13 @@ jQuery(function ($) {
         $(supports_create).prop('checked', data.support_creating_new_items);
         $(supports_create).prop( 'disabled', ( data.type === 'single-record' ) );
         $('tr.record-post-type-row, tr.connection-field-row').css('display', data.type === 'post-connections' ? 'revert' : 'none');
+
+        if (data.type === 'create-record') {
+          template_views_preset_values(false, 'slow');
+        } else {
+          template_views_preset_values(true, 'slow');
+        }
+
         callback();
       });
 
@@ -307,6 +367,12 @@ jQuery(function ($) {
       $(supports_create).prop('checked', data.support_creating_new_items);
       $(supports_create).prop( 'disabled', ( data.type !== 'list-sub-assigned-contacts' ) );
       $('tr.record-post-type-row, tr.connection-field-row').css('display', data.type === 'post-connections' ? 'revert' : 'none');
+
+      if (data.type === 'create-record') {
+        template_views_preset_values(false, 'slow', {post_type: data.record_type, preset_values: data.preset_values});
+      } else {
+        template_views_preset_values(true, 'slow');
+      }
 
       // Refresh post type fields list
       let post_types = window.dt_magic_links.dt_post_types;
@@ -476,6 +542,7 @@ jQuery(function ($) {
                 type: template['type'] ?? 'single-record',
                 record_type: template['record_type'] ?? 'contacts',
                 connection_fields: template['connection_fields'] ?? [],
+                preset_values: template['preset_values'] ?? {},
                 custom_fields: '',
                 show_recent_comments: template['show_recent_comments'],
                 send_submission_notifications: template['send_submission_notifications'] ?? true,
@@ -768,6 +835,7 @@ jQuery(function ($) {
     let support_creating_new_items = $('#ml_main_col_template_details_supports_create').prop('checked');
     let message = $('#ml_main_col_msg_textarea').val();
     let fields = fetch_selected_fields();
+    let preset_values = fetch_preset_values();
 
     // Validate values, to ensure all is present and correct within that department! ;)
     let update_msg = null;
@@ -807,7 +875,8 @@ jQuery(function ($) {
         'send_submission_notifications': send_submission_notifications,
         'support_creating_new_items': support_creating_new_items,
         'message': message,
-        'fields': fields
+        'fields': fields,
+        'preset_values': preset_values
       };
       if (type === 'post-connections') {
         template_obj.record_type = record_type;
@@ -819,6 +888,19 @@ jQuery(function ($) {
       $('#ml_main_col_update_form').submit();
 
     }
+  }
+
+  function fetch_preset_values() {
+    let preset_values = {};
+    $('#ml_main_col_preset_values_content').find('[name]').each(function (idx, element) {
+      const field_id = $(element).attr('name');
+      // For DT web components, we often need to get the value attribute or property
+      const value = $(element).val() || $(element).attr('value');
+      if (value) {
+        preset_values[field_id] = value;
+      }
+    });
+    return preset_values;
   }
 
   function fetch_selected_fields() {

--- a/admin/js/templates-tab.js
+++ b/admin/js/templates-tab.js
@@ -69,6 +69,10 @@ jQuery(function ($) {
     handle_selected_field_translation(evt);
   });
 
+  $(document).on('change', '#ml_main_col_selected_fields_sortable_field_enabled', function () {
+    update_preset_values_visibility();
+  });
+
   $(document).on('click', '#ml_main_col_update_but', function () {
     handle_update_request();
   });
@@ -247,6 +251,8 @@ jQuery(function ($) {
         placeholder: 'ui-state-highlight'
       }).disableSelection();
 
+      update_preset_values_visibility();
+
       view_selected_fields.fadeIn(fade_speed, function () {
         callback();
       });
@@ -281,6 +287,7 @@ jQuery(function ($) {
         success: function (response) {
           if (response.success) {
             $("#ml_main_col_preset_values_content").html(response.html);
+            update_preset_values_visibility();
           }
           view_preset_values.fadeIn(fade_speed, function () {
             callback();
@@ -580,6 +587,8 @@ jQuery(function ($) {
     if (field_id && field_label && !field_already_selected(field_id, field_label)) {
       $('.connected-sortable-fields').append(build_new_selected_field_html(field_id, field_label, field_type, field_enabled, field_translations));
 
+      update_preset_values_visibility();
+
       // Reset fields accordingly
       switch (field_type) {
         case 'dt' : {
@@ -597,6 +606,8 @@ jQuery(function ($) {
   function handle_selected_field_removal(evt) {
     let field_div = $(evt.currentTarget).parent().parent().parent().parent().parent();
     field_div.remove();
+
+    update_preset_values_visibility();
   }
 
   function handle_selected_field_translation(evt) {
@@ -928,6 +939,21 @@ jQuery(function ($) {
     });
 
     return fields;
+  }
+
+  function update_preset_values_visibility() {
+    const selectedFields = fetch_selected_fields()
+      .filter(field => field.type === 'dt' && field.enabled)
+      .map(field => field.id);
+
+    $('.preset-value-field-container').each(function (idx, element) {
+      const field_id = $(element).data('field-id');
+      if (selectedFields.includes(field_id)) {
+        $(element).show();
+      } else {
+        $(element).hide();
+      }
+    });
   }
 
 

--- a/admin/templates-tab.php
+++ b/admin/templates-tab.php
@@ -96,8 +96,27 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
                         $templates[ $template['post_type'] ] = [];
                     }
 
+                    // Process preset values if they exist
+                    if ( !empty( $template['preset_values'] ) && is_array( $template['preset_values'] ) ) {
+                        foreach ( $template['preset_values'] as $field_key => $preset_value ) {
+                            // Get field type from post type fields
+                            $post_type_fields = DT_Posts::get_post_field_settings( $template['post_type'] );
+                            if ( isset( $post_type_fields[$field_key] ) ) {
+                                $field_type = $post_type_fields[$field_key]['type'];
+
+                                // Transform value based on field type
+                                if ( $field_type === 'key_select' ) {
+                                    // Wrap value in object with 'key' property
+                                    $template['preset_values'][$field_key] = [
+                                        'key' => $preset_value
+                                    ];
+                                }
+                            }
+                        }
+                    }
+
                     // Update templates with the latest template version
-                    $templates[ $template['post_type'] ][ $template['id'] ] = $template;
+                    $templates[$template['post_type']][$template['id']] = $template;
 
                     // Finally, save updates
                     Disciple_Tools_Bulk_Magic_Link_Sender_API::update_option( Disciple_Tools_Bulk_Magic_Link_Sender_API::$option_dt_magic_links_templates, $templates );

--- a/admin/templates-tab.php
+++ b/admin/templates-tab.php
@@ -83,7 +83,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
 
                 // Fetch newly updated link object
                 $sanitized_input = filter_var( wp_unslash( $_POST['ml_main_col_update_form_template'] ), FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_FLAG_NO_ENCODE_QUOTES );
-                $template        = json_decode( $this->final_post_param_sanitization( $sanitized_input ), true );
+                $template        = json_decode( $this->final_post_param_sanitization( $sanitized_input ), true ) || [];
 
                 // Ensure we have something to work with
                 if ( ! empty( $template ) && isset( $template['id'] ) ) {

--- a/admin/templates-tab.php
+++ b/admin/templates-tab.php
@@ -83,7 +83,7 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
 
                 // Fetch newly updated link object
                 $sanitized_input = filter_var( wp_unslash( $_POST['ml_main_col_update_form_template'] ), FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_FLAG_NO_ENCODE_QUOTES );
-                $template        = json_decode( $this->final_post_param_sanitization( $sanitized_input ), true ) || [];
+                $template        = json_decode( $this->final_post_param_sanitization( $sanitized_input ), true );
 
                 // Ensure we have something to work with
                 if ( ! empty( $template ) && isset( $template['id'] ) ) {

--- a/admin/templates-tab.php
+++ b/admin/templates-tab.php
@@ -18,6 +18,9 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
     }
 
     private function process_scripts() {
+        dt_theme_enqueue_script( 'web-components', 'dt-assets/build/components/index.js', array(), false );
+        dt_theme_enqueue_style( 'web-components-css', 'dt-assets/build/css/light.min.css', array() );
+
         wp_register_style( 'daterangepicker-css', 'https://cdn.jsdelivr.net/npm/daterangepicker@3.1.0/daterangepicker.css', [], '3.1.0' );
         wp_enqueue_style( 'daterangepicker-css' );
         wp_enqueue_script( 'daterangepicker-js', 'https://cdn.jsdelivr.net/npm/daterangepicker@3.1.0/daterangepicker.js', [ 'moment' ], '3.1.0', true );
@@ -50,7 +53,9 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
                 'dt_magic_links_templates'      => $templates,
                 'dt_magic_links_template_types' => $template_types,
                 'dt_previous_updated_template'  => $this->fetch_previous_updated_template(),
-                'dt_languages_icon'             => esc_html( get_template_directory_uri() . '/dt-assets/images/languages.svg' )
+                'dt_languages_icon'             => esc_html( get_template_directory_uri() . '/dt-assets/images/languages.svg' ),
+                'dt_get_rendered_fields_url'    => Disciple_Tools_Bulk_Magic_Link_Sender_API::fetch_endpoint_get_rendered_fields_url(),
+                'dt_wp_nonce'                   => wp_create_nonce( 'wp_rest' )
             )
         );
     }
@@ -241,6 +246,17 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
                         </tbody>
                     </table>
                     <br>
+                    <!-- End Box -->
+
+                    <!-- Box -->
+                    <details style='display: none; background: #fff; border: 1px solid #ccd0d4; margin-bottom: 20px;' id='ml_main_col_preset_values'>
+                        <summary style="font-size: 14px; font-weight: 600; padding: 8px 12px; background: #f8f9fa; border-bottom: 1px solid #ccd0d4; cursor: pointer;">
+                            Preset Values
+                        </summary>
+                        <div style="padding: 12px;">
+                             <div id="ml_main_col_preset_values_content"></div>
+                        </div>
+                    </details>
                     <!-- End Box -->
 
                     <!-- Box -->

--- a/admin/templates-tab.php
+++ b/admin/templates-tab.php
@@ -105,11 +105,23 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Tab_Templates {
                                 $field_type = $post_type_fields[$field_key]['type'];
 
                                 // Transform value based on field type
-                                if ( $field_type === 'key_select' ) {
-                                    // Wrap value in object with 'key' property
-                                    $template['preset_values'][$field_key] = [
-                                        'key' => $preset_value
-                                    ];
+                                switch ( $field_type ) {
+                                    case 'key_select':
+                                        // Wrap value in object with 'key' property
+                                        $template['preset_values'][$field_key] = [
+                                            'key' => $preset_value
+                                        ];
+                                        break;
+                                    case 'date':
+                                    case 'datetime':
+                                        // Convert date string (YYYY-MM-DD) to timestamp
+                                        $timestamp = strtotime( $preset_value );
+                                        if ( $timestamp !== false ) {
+                                            $template['preset_values'][$field_key] = [
+                                                'timestamp' => $timestamp
+                                            ];
+                                        }
+                                        break;
                                 }
                             }
                         }

--- a/magic-link/magic-links-api.php
+++ b/magic-link/magic-links-api.php
@@ -1077,7 +1077,7 @@ Thanks!';
             if ( in_array( $field['type'] ?? '', $excluded_types ) ) {
                 continue;
             }
-            echo '<div style="margin-bottom: 1rem;">';
+            echo '<div class="preset-value-field-container" data-field-id="' . esc_attr( $field_key ) . '" style="margin-bottom: 1rem;">';
             Disciple_Tools_Magic_Links_Helper::render_field_for_display( $field_key, $field_settings, $post );
             echo '</div>';
         }

--- a/magic-link/magic-links-api.php
+++ b/magic-link/magic-links-api.php
@@ -1065,6 +1065,25 @@ Thanks!';
         }
     }
 
+    public static function render_all_fields_for_display( $post_type, $preset_values = [] ) {
+        $field_settings = DT_Posts::get_post_field_settings( $post_type, false );
+        $post = $preset_values;
+        $post['post_type'] = $post_type;
+
+        $excluded_types = [ 'connection', 'user_select', 'location', 'location_meta' ];
+
+        ob_start();
+        foreach ( $field_settings as $field_key => $field ) {
+            if ( in_array( $field['type'] ?? '', $excluded_types ) ) {
+                continue;
+            }
+            echo '<div style="margin-bottom: 1rem;">';
+            Disciple_Tools_Magic_Links_Helper::render_field_for_display( $field_key, $field_settings, $post );
+            echo '</div>';
+        }
+        return ob_get_clean();
+    }
+
     public static function fetch_endpoint_setup_payload_url(): string {
         return trailingslashit( site_url() ) . 'wp-json/disciple_tools_magic_links/v1/setup_payload';
     }
@@ -1091,6 +1110,10 @@ Thanks!';
 
     public static function fetch_endpoint_report_url(): string {
         return trailingslashit( site_url() ) . 'wp-json/disciple_tools_magic_links/v1/report';
+    }
+
+    public static function fetch_endpoint_get_rendered_fields_url(): string {
+        return trailingslashit( site_url() ) . 'wp-json/disciple_tools_magic_links/v1/get_rendered_fields';
     }
 
     public static function fetch_endpoint_typeahead_users_teams_groups_url(): string {

--- a/magic-link/magic-links-helper.php
+++ b/magic-link/magic-links-helper.php
@@ -42,7 +42,7 @@ class Disciple_Tools_Magic_Links_Helper
      * @return void
      */
     public static function render_field_for_display( $field_key, $fields, $post, $show_extra_controls = false, $show_hidden = false, $field_id_prefix = '' ) {
-        $disabled = $fields[$field_key]['readonly'] ? 'disabled' : '';
+        $disabled = ( isset( $fields[$field_key]['readonly'] ) && $fields[$field_key]['readonly'] ) ? 'disabled' : '';
 //        if ( isset( $post['post_type'] ) && isset( $post['ID'] ) && $post['ID'] !== 0 ) {
 //            $can_update = DT_Posts::can_update( $post['post_type'], $post['ID'] );
 //        } else {
@@ -102,13 +102,24 @@ class Disciple_Tools_Magic_Links_Helper
                 </dt-single-select>
 
             <?php elseif ( $field_type === 'tags' ) : ?>
-                <?php $value = array_map(function ( $value ) {
-                    return $value;
-                }, $post[$field_key] ?? []);
+                <?php
+                $value = array_values( $post[$field_key] ?? [] );
+                $options = [];
+                $raw_options = DT_Posts::get_multi_select_options( $post['post_type'] ?? 'contacts', $field_key );
+                if ( is_array( $raw_options ) ) {
+                    foreach ( $raw_options as $option ) {
+                        if ( is_string( $option ) ) {
+                            $options[] = [ 'id' => $option ];
+                        } elseif ( is_array( $option ) && isset( $option['label'] ) ) {
+                            $options[] = [ 'id' => $option['label'] ];
+                        }
+                    }
+                }
                 ?>
                 <dt-tags
                     <?php echo wp_kses_post( $shared_attributes ) ?>
                     value="<?php echo esc_attr( json_encode( $value ) ) ?>"
+                    options="<?php echo esc_attr( json_encode( $options ) ) ?>"
                     placeholder="<?php echo esc_html( sprintf( _x( 'Search %s', "Search 'something'", 'disciple_tools' ), $fields[$field_key]['name'] ) )?>"
                     allowAdd
                 >

--- a/magic-link/magic-links-helper.php
+++ b/magic-link/magic-links-helper.php
@@ -93,7 +93,7 @@ class Disciple_Tools_Magic_Links_Helper
             ';
 
             if ( $field_type === 'key_select' ) :
-                if ( isset( $post[$field_key] ) && is_string( $post[$field_key] ) ) {
+                if ( isset( $post[$field_key] ) && !isset( $post[$field_key]['key']) ) {
                     // reformat post value to match expected syntax
                     $post[$field_key] = [
                         'key' => $post[$field_key],

--- a/magic-link/magic-links-helper.php
+++ b/magic-link/magic-links-helper.php
@@ -93,7 +93,7 @@ class Disciple_Tools_Magic_Links_Helper
             ';
 
             if ( $field_type === 'key_select' ) :
-                if ( isset( $post[$field_key] ) && !isset( $post[$field_key]['key']) ) {
+                if ( isset( $post[$field_key] ) && !isset( $post[$field_key]['key'] ) ) {
                     // reformat post value to match expected syntax
                     $post[$field_key] = [
                         'key' => $post[$field_key],

--- a/magic-link/magic-links-helper.php
+++ b/magic-link/magic-links-helper.php
@@ -91,15 +91,16 @@ class Disciple_Tools_Magic_Links_Helper
                   ' . esc_html( $disabled ) . '
                   ' . ( $is_private ? 'private privateLabel=' . esc_attr( _x( "Private Field: Only I can see it\'s content", 'disciple_tools' ) ) : null ) . '
             ';
+
             if ( $field_type === 'key_select' ) :
+                if ( isset( $post[$field_key] ) && is_string( $post[$field_key] ) ) {
+                    // reformat post value to match expected syntax
+                    $post[$field_key] = [
+                        'key' => $post[$field_key],
+                    ];
+                }
+                DT_Components::render_key_select( $field_key, $fields, $post );
                 ?>
-                <dt-single-select class="select-field"
-                    <?php echo wp_kses_post( $shared_attributes ) ?>
-                                  value="<?php echo esc_attr( key_exists( $field_key, $post ) ? $post[$field_key]['key'] : null ) ?>"
-                                  options="<?php echo esc_attr( json_encode( self::assoc_to_array( $fields[$field_key]['default'] ) ) ) ?>"
-                >
-                    <?php self::render_icon_slot( $fields[$field_key] ) ?>
-                </dt-single-select>
 
             <?php elseif ( $field_type === 'tags' ) : ?>
                 <?php

--- a/magic-link/templates/create-record.php
+++ b/magic-link/templates/create-record.php
@@ -812,9 +812,15 @@ class Disciple_Tools_Magic_Links_Template_Create_Record extends DT_Magic_Url_Bas
                                             $this->post_field_settings[$field_id]['required'] = true;
                                         }
 
+                                        $options = [];
+
+                                        if ( $field_type === 'tags' ) {
+                                            $options['static_options'] = true;
+                                        }
+
                                         // Check if function exists
                                         if ( function_exists( 'render_field_for_display' ) ) {
-                                            render_field_for_display( $field_id, $this->post_field_settings, $this->post, null, null, null, [] );
+                                            render_field_for_display( $field_id, $this->post_field_settings, $this->post, null, null, null, $options );
                                         } else {
                                             echo '<p>Error: Field rendering function not found</p>';
                                         }

--- a/magic-link/templates/create-record.php
+++ b/magic-link/templates/create-record.php
@@ -108,13 +108,24 @@ class Disciple_Tools_Magic_Links_Template_Create_Record extends DT_Magic_Url_Bas
         }
 
         /**
-         * Initialize empty post for new record creation - no existing post needed
+         * Initialize empty post for new record creation, incorporating preset values if available.
          */
 
         $this->post = [
-            'ID' => 0,
             'post_type' => $this->record_type,
         ];
+
+        if ( ! empty( $this->template['preset_values'] ) && is_array( $this->template['preset_values'] ) ) {
+            foreach ( $this->template['preset_values'] as $key => $value ) {
+                if ( is_string( $value ) && ( strpos( $value, '[' ) === 0 || strpos( $value, '{' ) === 0 ) ) {
+                    $decoded = json_decode( htmlspecialchars_decode( $value ), true );
+                    if ( json_last_error() === JSON_ERROR_NONE ) {
+                        $value = $decoded;
+                    }
+                }
+                $this->post[$key] = $value;
+            }
+        }
 
         /**
          * Attempt to load corresponding link object, if a valid incoming id has been detected.
@@ -237,12 +248,12 @@ class Disciple_Tools_Magic_Links_Template_Create_Record extends DT_Magic_Url_Bas
         ?>
         <style>
             html {
-                height: 100%;
+                min-height: 100%;
             }
             body {
                 background-color: white;
                 padding: 1em;
-                height: 100%;
+                min-height: 100%;
             }
 
             .create-form {
@@ -783,7 +794,8 @@ class Disciple_Tools_Magic_Links_Template_Create_Record extends DT_Magic_Url_Bas
                                         'link',
                                         'communication_channel',
                                         'location',
-                                        'location_meta'
+                                        'location_meta',
+                                        'tags'
                                     ] ) ) {
                                         continue;
                                     }
@@ -802,7 +814,7 @@ class Disciple_Tools_Magic_Links_Template_Create_Record extends DT_Magic_Url_Bas
 
                                         // Check if function exists
                                         if ( function_exists( 'render_field_for_display' ) ) {
-                                            render_field_for_display( $field_id, $this->post_field_settings, $empty_post, null, null, null, [] );
+                                            render_field_for_display( $field_id, $this->post_field_settings, $this->post, null, null, null, [] );
                                         } else {
                                             echo '<p>Error: Field rendering function not found</p>';
                                         }
@@ -830,9 +842,9 @@ class Disciple_Tools_Magic_Links_Template_Create_Record extends DT_Magic_Url_Bas
                                 $this->post_field_settings['name']['required'] = true;
 
                                 if ( function_exists( 'render_field_for_display' ) ) {
-                                    render_field_for_display( 'name', $this->post_field_settings, $empty_post );
+                                    render_field_for_display( 'name', $this->post_field_settings, $this->post );
                                 } else if ( class_exists( 'Disciple_Tools_Magic_Links_Helper' ) ) {
-                                    Disciple_Tools_Magic_Links_Helper::render_field_for_display( 'name', $this->post_field_settings, $empty_post );
+                                    Disciple_Tools_Magic_Links_Helper::render_field_for_display( 'name', $this->post_field_settings, $this->post );
                                 }
                                 ?>
                             </div>
@@ -896,6 +908,17 @@ class Disciple_Tools_Magic_Links_Template_Create_Record extends DT_Magic_Url_Bas
 
         // Prepare record fields for DT_Posts::create_post
         $updates = [];
+        if ( ! empty( $this->template['preset_values'] ) && is_array( $this->template['preset_values'] ) ) {
+            foreach ( $this->template['preset_values'] as $key => $value ) {
+                if ( is_string( $value ) && ( strpos( $value, '[' ) === 0 || strpos( $value, '{' ) === 0 ) ) {
+                    $decoded = json_decode( htmlspecialchars_decode( $value ), true );
+                    if ( json_last_error() === JSON_ERROR_NONE ) {
+                        $value = $decoded;
+                    }
+                }
+                $updates[$key] = $value;
+            }
+        }
 
         // Process DT field values using the same approach as create-contact.php
         foreach ( $params['fields']['dt'] ?? [] as $field ) {

--- a/rest-api/rest-api.php
+++ b/rest-api/rest-api.php
@@ -121,6 +121,29 @@ class Disciple_Tools_Bulk_Magic_Link_Sender_Endpoints {
                 }
             ]
         );
+        register_rest_route(
+            $namespace, '/get_rendered_fields', [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_rendered_fields' ],
+                'permission_callback' => function ( WP_REST_Request $request ) {
+                    return $this->has_permission();
+                }
+            ]
+        );
+    }
+
+    public function get_rendered_fields( WP_REST_Request $request ): array {
+        $params = $request->get_params();
+        $post_type = $params['post_type'] ?? 'contacts';
+        $preset_values = $params['preset_values'] ?? [];
+        if ( is_string( $preset_values ) ) {
+            $preset_values = json_decode( $preset_values, true ) ?? [];
+        }
+
+        return [
+            'success' => true,
+            'html' => Disciple_Tools_Bulk_Magic_Link_Sender_API::render_all_fields_for_display( $post_type, $preset_values )
+        ];
     }
 
     public function setup_payload( WP_REST_Request $request ): array{


### PR DESCRIPTION
- Add a "Preset Values" configuration section to the template admin interface for record creation.
- Create a REST endpoint to dynamically render fields for selecting preset values using Disciple Tools web components.
- Update the record creation logic to apply configured preset values when a new record is generated via a magic link.
- Enhance tag field rendering to support options and proper value initialization in the admin UI.

## Use Case
Site admins could create multiple Create Record templates for different scenarios. For adding a personal contact, the template could have the Source field set to Personal by default. For a specific outreach campaign where users are collecting names and contact info in the street, the template could preset a specific tag or campaign to streamline data collection.